### PR TITLE
Nested save in the endpoints

### DIFF
--- a/hauki/settings.py
+++ b/hauki/settings.py
@@ -268,6 +268,10 @@ SESSION_COOKIE_NAME = "%s-sessionid" % env("COOKIE_PREFIX")
 # https://www.django-rest-framework.org/api-guide/settings/
 
 REST_FRAMEWORK = {
+    "DEFAULT_RENDERER_CLASSES": [
+        "rest_framework.renderers.JSONRenderer",
+        "hours.renderers.BrowsableAPIRendererWithoutForms",
+    ],
     "DEFAULT_FILTER_BACKENDS": [
         "rest_framework.filters.OrderingFilter",
         "django_filters.rest_framework.DjangoFilterBackend",

--- a/hours/renderers.py
+++ b/hours/renderers.py
@@ -1,0 +1,20 @@
+from rest_framework.renderers import BrowsableAPIRenderer
+
+
+# From:
+# https://bradmontgomery.net/blog/disabling-forms-django-rest-frameworks-browsable-api/
+class BrowsableAPIRendererWithoutForms(BrowsableAPIRenderer):
+    """Renders the browsable api, but excludes the html form."""
+
+    def get_context(self, *args, **kwargs):
+        ctx = super().get_context(*args, **kwargs)
+        return ctx
+
+    def get_rendered_html_form(self, data, view, method, request):
+        """Returns empty html for the html form, except True for DELETE
+        and OPTIONS methods to show buttons for them"""
+
+        if method in ("DELETE", "OPTIONS"):
+            return True
+
+        return ""

--- a/hours/serializers.py
+++ b/hours/serializers.py
@@ -1,4 +1,5 @@
 from django_orghierarchy.models import Organization
+from drf_writable_nested import WritableNestedModelSerializer
 from enumfields.drf import EnumField, EnumSupportSerializerMixin
 from modeltranslation import settings as mt_settings
 from modeltranslation.translator import NotRegistered, translator
@@ -132,6 +133,12 @@ class ResourceSerializer(
 class TimeSpanSerializer(
     TranslationSerializerMixin, EnumSupportSerializerMixin, serializers.ModelSerializer
 ):
+    # TODO: Group cannot be required when creating a nested item. But it should
+    #       be when creating a new TimeSpan.
+    group = serializers.PrimaryKeyRelatedField(
+        required=False, queryset=TimeSpanGroup.objects.all()
+    )
+
     class Meta:
         model = TimeSpan
         fields = [
@@ -152,6 +159,12 @@ class TimeSpanSerializer(
 class RuleSerializer(
     TranslationSerializerMixin, EnumSupportSerializerMixin, serializers.ModelSerializer
 ):
+    # TODO: Group cannot be required when creating a nested item. But it should
+    #       be when creating a new Rule.
+    group = serializers.PrimaryKeyRelatedField(
+        required=False, queryset=TimeSpanGroup.objects.all()
+    )
+
     class Meta:
         model = Rule
         fields = [
@@ -169,9 +182,16 @@ class RuleSerializer(
         ]
 
 
-class TimeSpanGroupSerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
-    time_spans = TimeSpanSerializer(many=True)
-    rules = RuleSerializer(many=True)
+class TimeSpanGroupSerializer(
+    EnumSupportSerializerMixin, WritableNestedModelSerializer
+):
+    # TODO: Period cannot be required when creating a nested item. But it should
+    #       be when creating a new TimeSpanGroup.
+    period = serializers.PrimaryKeyRelatedField(
+        required=False, queryset=DatePeriod.objects.all()
+    )
+    time_spans = TimeSpanSerializer(many=True, required=False, allow_null=True)
+    rules = RuleSerializer(many=True, required=False, allow_null=True)
 
     class Meta:
         model = TimeSpanGroup
@@ -179,9 +199,13 @@ class TimeSpanGroupSerializer(EnumSupportSerializerMixin, serializers.ModelSeria
 
 
 class DatePeriodSerializer(
-    TranslationSerializerMixin, EnumSupportSerializerMixin, serializers.ModelSerializer
+    TranslationSerializerMixin,
+    EnumSupportSerializerMixin,
+    WritableNestedModelSerializer,
 ):
-    time_span_groups = TimeSpanGroupSerializer(many=True)
+    time_span_groups = TimeSpanGroupSerializer(
+        many=True, required=False, allow_null=True
+    )
 
     class Meta:
         model = DatePeriod

--- a/hours/tests/test_dateperiod_api.py
+++ b/hours/tests/test_dateperiod_api.py
@@ -1,0 +1,345 @@
+import datetime
+import json
+
+import pytest
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db import IntegrityError
+from django.urls import reverse
+
+from hours.enums import RuleContext, RuleSubject, State, Weekday
+from hours.models import DatePeriod
+
+
+@pytest.mark.django_db
+def test_create_date_period_no_time_span_groups(resource, api_client):
+    url = reverse("date_period-list")
+
+    data = {
+        "resource": resource.id,
+        "name": "Testperiod",
+        "description": "Testperiod desc",
+        "start_date": "2020-01-01",
+        "end_date": "2020-12-31",
+        "resource_state": "undefined",
+        "override": "false",
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    date_period = DatePeriod.objects.get(pk=response.data["id"])
+
+    assert date_period.resource == resource
+    assert date_period.start_date == datetime.date(year=2020, month=1, day=1)
+    assert date_period.time_span_groups.count() == 0
+
+
+@pytest.mark.django_db
+def test_create_date_period_one_time_span_group_one_time_span(resource, api_client):
+    url = reverse("date_period-list")
+
+    data = {
+        "resource": resource.id,
+        "name": "Testperiod",
+        "description": "Testperiod desc",
+        "start_date": "2020-01-01",
+        "end_date": "2020-12-31",
+        "resource_state": "undefined",
+        "override": "false",
+        "time_span_groups": [
+            {
+                "time_spans": [
+                    {
+                        "full_day": True,
+                        "resource_state": "closed",
+                    }
+                ]
+            }
+        ],
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    date_period = DatePeriod.objects.get(pk=response.data["id"])
+
+    assert date_period.resource == resource
+    assert date_period.start_date == datetime.date(year=2020, month=1, day=1)
+    assert date_period.time_span_groups.count() == 1
+
+    time_span_group = date_period.time_span_groups.first()
+    assert time_span_group.time_spans.count() == 1
+    assert time_span_group.rules.count() == 0
+
+    time_span = time_span_group.time_spans.first()
+    assert time_span.start_time is None
+    assert time_span.end_time is None
+    assert time_span.full_day is True
+    assert time_span.resource_state == State.CLOSED
+
+
+@pytest.mark.django_db
+def test_create_date_period_one_time_span_group_one_time_span_one_rule(
+    resource, api_client
+):
+    url = reverse("date_period-list")
+
+    data = {
+        "resource": resource.id,
+        "name": "Testperiod",
+        "description": "Testperiod desc",
+        "start_date": "2020-01-01",
+        "end_date": "2020-12-31",
+        "resource_state": "undefined",
+        "override": "false",
+        "time_span_groups": [
+            {
+                "time_spans": [
+                    {
+                        "full_day": True,
+                        "resource_state": "closed",
+                    }
+                ],
+                "rules": [
+                    {
+                        "context": "period",
+                        "subject": "week",
+                        "start": 1,
+                    }
+                ],
+            }
+        ],
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    date_period = DatePeriod.objects.get(pk=response.data["id"])
+
+    assert date_period.resource == resource
+    assert date_period.start_date == datetime.date(year=2020, month=1, day=1)
+    assert date_period.time_span_groups.count() == 1
+
+    time_span_group = date_period.time_span_groups.first()
+    assert time_span_group.time_spans.count() == 1
+    assert time_span_group.rules.count() == 1
+
+    time_span = time_span_group.time_spans.first()
+    assert time_span.start_time is None
+    assert time_span.end_time is None
+    assert time_span.full_day is True
+    assert time_span.resource_state == State.CLOSED
+
+    rule = time_span_group.rules.first()
+    assert rule.context == RuleContext.PERIOD
+    assert rule.subject == RuleSubject.WEEK
+    assert rule.start == 1
+
+
+@pytest.mark.django_db
+def test_update_date_period_no_time_span_groups(
+    resource, date_period_factory, api_client
+):
+    date_period = date_period_factory(
+        resource=resource,
+        name="Testperiod",
+        start_date=datetime.date(year=2020, month=1, day=1),
+        end_date=datetime.date(year=2020, month=12, day=31),
+    )
+
+    url = reverse("date_period-detail", kwargs={"pk": date_period.pk})
+
+    data = {
+        "id": date_period.id,
+        "name": "Testperiod edit",
+        "description": "Testperiod desc",
+        "start_date": "2020-02-02",
+        "end_date": "2020-11-30",
+    }
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    date_period = DatePeriod.objects.get(pk=response.data["id"])
+
+    assert date_period.resource == resource
+    assert date_period.name == "Testperiod edit"
+    assert date_period.start_date == datetime.date(year=2020, month=2, day=2)
+    assert date_period.time_span_groups.count() == 0
+
+
+@pytest.mark.django_db
+def test_update_date_period_keep_one_time_span(
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    time_span_factory,
+    api_client,
+):
+    date_period = date_period_factory(
+        resource=resource,
+        name="Testperiod",
+        start_date=datetime.date(year=2020, month=1, day=1),
+        end_date=datetime.date(year=2020, month=12, day=31),
+    )
+
+    time_span_group = time_span_group_factory(period=date_period)
+
+    time_span_factory(
+        group=time_span_group,
+        start_time=datetime.time(hour=8, minute=0),
+        end_time=datetime.time(hour=16, minute=0),
+        weekdays=Weekday.business_days(),
+    )
+
+    url = reverse("date_period-detail", kwargs={"pk": date_period.pk})
+
+    data = {
+        "id": date_period.id,
+        "name": "Testperiod edit",
+        "description": "Testperiod desc",
+        "start_date": "2020-02-02",
+        "end_date": "2020-11-30",
+    }
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    date_period = DatePeriod.objects.get(pk=response.data["id"])
+
+    assert date_period.resource == resource
+    assert date_period.name == "Testperiod edit"
+    assert date_period.start_date == datetime.date(year=2020, month=2, day=2)
+    assert date_period.time_span_groups.count() == 1
+    assert time_span_group.time_spans.count() == 1
+
+    time_span = time_span_group.time_spans.first()
+    assert time_span.start_time == datetime.time(hour=8, minute=0)
+    assert time_span.end_time == datetime.time(hour=16, minute=0)
+
+
+@pytest.mark.django_db
+def test_update_date_period_add_one_time_span(
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    time_span_factory,
+    api_client,
+):
+    date_period = date_period_factory(
+        resource=resource,
+        name="Testperiod",
+        start_date=datetime.date(year=2020, month=1, day=1),
+        end_date=datetime.date(year=2020, month=12, day=31),
+    )
+
+    time_span_group = time_span_group_factory(period=date_period)
+
+    time_span = time_span_factory(
+        group=time_span_group,
+        start_time=datetime.time(hour=8, minute=0),
+        end_time=datetime.time(hour=16, minute=0),
+        weekdays=Weekday.business_days(),
+    )
+
+    url = reverse("date_period-detail", kwargs={"pk": date_period.pk})
+
+    data = {
+        "id": date_period.id,
+        "name": "Testperiod edit",
+        "description": "Testperiod desc",
+        "start_date": "2020-02-02",
+        "end_date": "2020-11-30",
+        "time_span_groups": [
+            {
+                "id": time_span_group.id,
+                "time_spans": [
+                    {"id": time_span.id},
+                    {
+                        "full_day": True,
+                        "resource_state": "closed",
+                    },
+                ],
+            }
+        ],
+    }
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    date_period = DatePeriod.objects.get(pk=response.data["id"])
+
+    assert date_period.resource == resource
+    assert date_period.name == "Testperiod edit"
+    assert date_period.start_date == datetime.date(year=2020, month=2, day=2)
+    assert date_period.time_span_groups.count() == 1
+    assert time_span_group.time_spans.count() == 2
+
+    existing_time_span = time_span_group.time_spans.get(pk=time_span.id)
+    assert existing_time_span.start_time == datetime.time(hour=8, minute=0)
+    assert existing_time_span.end_time == datetime.time(hour=16, minute=0)
+
+    new_time_span = time_span_group.time_spans.exclude(pk=time_span.id).first()
+    assert new_time_span.full_day is True
+    assert new_time_span.resource_state == State.CLOSED
+
+
+@pytest.mark.django_db
+def test_create_time_span_no_group(resource, api_client):
+    url = reverse("time_spans-list")
+
+    data = {
+        "full_day": True,
+        "resource_state": "closed",
+    }
+
+    # TODO: Change when viewsets changed to use different serializer for
+    #       update and create.
+    with pytest.raises(IntegrityError):
+        api_client.post(
+            url,
+            data=json.dumps(data, cls=DjangoJSONEncoder),
+            content_type="application/json",
+        )

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ django-modeltranslation
 django-orghierarchy
 django-simple-history
 djangorestframework
+drf-writable-nested
 holidays
 numpy
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ django-simple-history==2.11.0  # via -r requirements.in
 django==3.1.2             # via -r requirements.in, django-cors-headers, django-extra-fields, django-filter, django-helusers, django-model-utils, django-modeltranslation, django-mptt, djangorestframework, drf-oidc-auth
 djangorestframework==3.12.1  # via -r requirements.in, django-extra-fields, django-orghierarchy, drf-oidc-auth
 drf-oidc-auth==0.10.0     # via django-helusers
+drf-writable-nested==0.6.2  # via -r requirements.in
 ecdsa==0.14.1             # via python-jose
 future==0.18.2            # via pyjwkest
 holidays==0.10.3          # via -r requirements.in


### PR DESCRIPTION
Allow saving nested items in the serializers. Also disable HTML forms in the browsable API.

Refs HAUKI-198