### PR TITLE
Slim down the requirements a bit

### DIFF
--- a/hours/importer/kirjastot.py
+++ b/hours/importer/kirjastot.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 from datetime import date, datetime, time
+from functools import reduce
 from itertools import groupby
-from math import ceil
+from math import ceil, gcd
 from operator import itemgetter
 
 import holidays
-import numpy as np
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from django import db
@@ -82,6 +82,10 @@ KIRKANTA_FIXED_GROUPS = {
         },
     ],
 }
+
+
+def lcm(denominators):
+    return reduce(lambda a, b: a * b // gcd(a, b), denominators)
 
 
 @register_importer
@@ -229,7 +233,7 @@ class KirjastotImporter(Importer):
         repetition_lengths = [
             len(repetition) for repetition in repetition_pattern.values()
         ]
-        max_week = np.lcm.reduce(repetition_lengths)
+        max_week = lcm(repetition_lengths)
         # however, len(data) is the maximum, no need to do more than that!
         if max_week > len(data) / 7:
             max_week = int(ceil(len(data) / 7))

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,7 +8,6 @@ flake8
 freezegun
 ipython
 isort
-jupyter
 pre-commit
 pytest
 pytest-cov
@@ -16,4 +15,3 @@ pytest-django
 pytest-factoryboy
 requests-mock
 safety
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,26 +5,20 @@
 #    pip-compile requirements-dev.in
 #
 appdirs==1.4.4            # via black, virtualenv
-appnope==0.1.0            # via ipykernel, ipython
-argon2-cffi==20.1.0       # via notebook
-async-generator==1.10     # via nbclient
-attrs==20.2.0             # via jsonschema, pytest
+appnope==0.1.0            # via ipython
+attrs==20.2.0             # via pytest
 backcall==0.2.0           # via ipython
 bandit==1.6.2             # via -r requirements-dev.in
 black==20.8b1             # via -r requirements-dev.in
-bleach==3.2.1             # via nbconvert
 certifi==2020.6.20        # via -c requirements.txt, requests
-cffi==1.14.3              # via argon2-cffi
 cfgv==3.2.0               # via pre-commit
 chardet==3.0.4            # via -c requirements.txt, requests
 click==7.1.2              # via black, safety
 coverage==5.3             # via pytest-cov
 decorator==4.4.2          # via ipython
-defusedxml==0.6.0         # via nbconvert
 distlib==0.3.1            # via virtualenv
 django-extensions==3.0.9  # via -r requirements-dev.in
 dparse==0.5.1             # via safety
-entrypoints==0.3          # via nbconvert
 factory-boy==3.1.0        # via -r requirements-dev.in, pytest-factoryboy
 faker==4.5.0              # via -r requirements-dev.in, factory-boy
 filelock==3.0.12          # via virtualenv
@@ -34,34 +28,17 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.9          # via bandit
 identify==1.5.5           # via pre-commit
 idna==2.10                # via -c requirements.txt, requests
-importlib-metadata==2.0.0  # via flake8, jsonschema, pluggy, pre-commit, pytest, stevedore, virtualenv
+importlib-metadata==2.0.0  # via flake8, pluggy, pre-commit, pytest, stevedore, virtualenv
 inflection==0.5.1         # via pytest-factoryboy
 iniconfig==1.0.1          # via pytest
-ipykernel==5.3.4          # via ipywidgets, jupyter, jupyter-console, notebook, qtconsole
-ipython-genutils==0.2.0   # via nbformat, notebook, qtconsole, traitlets
-ipython==7.18.1           # via -r requirements-dev.in, ipykernel, ipywidgets, jupyter-console
-ipywidgets==7.5.1         # via jupyter
+ipython-genutils==0.2.0   # via traitlets
+ipython==7.18.1           # via -r requirements-dev.in
 isort==5.5.4              # via -r requirements-dev.in
 jedi==0.17.2              # via ipython
-jinja2==2.11.2            # via nbconvert, notebook
-jsonschema==3.2.0         # via nbformat
-jupyter-client==6.1.7     # via ipykernel, jupyter-console, nbclient, notebook, qtconsole
-jupyter-console==6.2.0    # via jupyter
-jupyter-core==4.6.3       # via jupyter-client, nbconvert, nbformat, notebook, qtconsole
-jupyter==1.0.0            # via -r requirements-dev.in
-jupyterlab-pygments==0.1.2  # via nbconvert
-markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
-mistune==0.8.4            # via nbconvert
 mypy-extensions==0.4.3    # via black
-nbclient==0.5.0           # via nbconvert
-nbconvert==6.0.6          # via jupyter, notebook
-nbformat==5.0.7           # via ipywidgets, nbclient, nbconvert, notebook
-nest-asyncio==1.4.1       # via nbclient
 nodeenv==1.5.0            # via pre-commit
-notebook==6.1.4           # via jupyter, widgetsnbextension
-packaging==20.4           # via bleach, dparse, pytest, safety
-pandocfilters==1.4.2      # via nbconvert
+packaging==20.4           # via dparse, pytest, safety
 parso==0.7.1              # via jedi
 pathspec==0.8.0           # via black
 pbr==5.5.0                # via stevedore
@@ -69,46 +46,34 @@ pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pluggy==0.13.1            # via pytest
 pre-commit==2.7.1         # via -r requirements-dev.in
-prometheus-client==0.8.0  # via notebook
-prompt-toolkit==3.0.7     # via ipython, jupyter-console
-ptyprocess==0.6.0         # via pexpect, terminado
+prompt-toolkit==3.0.7     # via ipython
+ptyprocess==0.6.0         # via pexpect
 py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via flake8
-pycparser==2.20           # via cffi
 pyflakes==2.2.0           # via flake8
-pygments==2.7.1           # via ipython, jupyter-console, jupyterlab-pygments, nbconvert, qtconsole
+pygments==2.7.1           # via ipython
 pyparsing==2.4.7          # via packaging
-pyrsistent==0.17.3        # via jsonschema
 pytest-cov==2.10.1        # via -r requirements-dev.in
 pytest-django==3.10.0     # via -r requirements-dev.in
 pytest-factoryboy==2.0.3  # via -r requirements-dev.in
 pytest==6.1.0             # via -r requirements-dev.in, pytest-cov, pytest-django, pytest-factoryboy
-python-dateutil==2.8.1    # via -c requirements.txt, faker, freezegun, jupyter-client
+python-dateutil==2.8.1    # via -c requirements.txt, faker, freezegun
 pyyaml==5.3.1             # via bandit, dparse, pre-commit
-pyzmq==19.0.2             # via jupyter-client, notebook, qtconsole
-qtconsole==4.7.7          # via jupyter
-qtpy==1.9.0               # via qtconsole
 regex==2020.9.27          # via black
 requests-mock==1.8.0      # via -r requirements-dev.in
 requests==2.24.0          # via -c requirements.txt, requests-mock, safety
 safety==1.9.0             # via -r requirements-dev.in
-send2trash==1.5.0         # via notebook
-six==1.15.0               # via -c requirements.txt, argon2-cffi, bandit, bleach, jsonschema, packaging, python-dateutil, requests-mock, virtualenv
+six==1.15.0               # via -c requirements.txt, bandit, packaging, python-dateutil, requests-mock, virtualenv
 smmap==3.0.4              # via gitdb
 stevedore==3.2.2          # via bandit
-terminado==0.9.1          # via notebook
-testpath==0.4.4           # via nbconvert
 text-unidecode==1.3       # via faker
 toml==0.10.1              # via black, dparse, pre-commit, pytest
-tornado==6.0.4            # via ipykernel, jupyter-client, notebook, terminado
-traitlets==5.0.4          # via ipykernel, ipython, ipywidgets, jupyter-client, jupyter-core, nbclient, nbconvert, nbformat, notebook, qtconsole
+traitlets==5.0.4          # via ipython
 typed-ast==1.4.1          # via black
 typing-extensions==3.7.4.3  # via black
 urllib3==1.25.10          # via -c requirements.txt, requests
 virtualenv==20.0.32       # via pre-commit
 wcwidth==0.2.5            # via prompt-toolkit
-webencodings==0.5.1       # via bleach
-widgetsnbextension==3.5.1  # via ipywidgets
 zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,4 @@
 Django
-delorean
 django-cors-headers
 django-enumfields
 django-environ
@@ -13,8 +12,6 @@ django-simple-history
 djangorestframework
 drf-writable-nested
 holidays
-numpy
-pandas
 psycopg2
 requests-cache
 sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,9 @@
 #    pip-compile requirements.in
 #
 asgiref==3.2.10           # via django
-babel==2.8.0              # via delorean
 certifi==2020.6.20        # via requests, sentry-sdk
 chardet==3.0.4            # via requests
 convertdate==2.2.2        # via holidays
-delorean==1.0.0           # via -r requirements.in
 django-cors-headers==3.5.0  # via -r requirements.in
 django-enumfields==2.0.0  # via -r requirements.in
 django-environ==0.4.5     # via -r requirements.in
@@ -29,19 +27,16 @@ drf-writable-nested==0.6.2  # via -r requirements.in
 ecdsa==0.14.1             # via python-jose
 future==0.18.2            # via pyjwkest
 holidays==0.10.3          # via -r requirements.in
-humanize==3.0.0           # via delorean
 idna==2.10                # via requests
 korean-lunar-calendar==0.2.1  # via holidays
-numpy==1.19.2             # via -r requirements.in, pandas
-pandas==1.1.2             # via -r requirements.in
 psycopg2==2.8.6           # via -r requirements.in
 pyasn1==0.4.8             # via python-jose, rsa
 pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via drf-oidc-auth
 pymeeus==0.3.7            # via convertdate
-python-dateutil==2.8.1    # via delorean, holidays, pandas
+python-dateutil==2.8.1    # via holidays
 python-jose==3.2.0        # via django-helusers
-pytz==2020.1              # via babel, convertdate, delorean, django, pandas, tzlocal
+pytz==2020.1              # via convertdate, django
 requests-cache==0.5.2     # via -r requirements.in
 requests==2.24.0          # via django-helusers, django-orghierarchy, pyjwkest, requests-cache
 rsa==4.6                  # via python-jose
@@ -49,9 +44,5 @@ sentry-sdk==0.18.0        # via -r requirements.in
 six==1.15.0               # via django-modeltranslation, django-simple-history, ecdsa, holidays, pyjwkest, python-dateutil, python-jose
 sqlparse==0.3.1           # via django
 swapper==1.1.2.post1      # via django-orghierarchy
-tzlocal==2.1              # via delorean
 urllib3==1.25.10          # via requests, sentry-sdk
 whitenoise==5.2.0         # via -r requirements.in
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
We can uninstall some requirements as they are not used anymore. Also from numpy we used one function that could be replaced easily. This reduces the deployment size roughly in half.

Site packages size:

with the old requirements.txt: 278M
with the old requirements-dev.txt: 404M

with the new requirements.txt: 114M
with the new requirements-dev.txt: 177M
