### PR TITLE
Add permission checks to the API endpoints

### DIFF
--- a/hauki/settings.py
+++ b/hauki/settings.py
@@ -281,6 +281,9 @@ REST_FRAMEWORK = {
         "hours.authentication.HaukiTokenAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticatedOrReadOnly",
+    ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 20,
     "MAX_PAGE_SIZE": 100,

--- a/hours/models.py
+++ b/hours/models.py
@@ -272,11 +272,10 @@ class Resource(SoftDeletableModel, TimeStampedModel):
 
     def get_organizations(self):
         """Returns the resources and its parents organizations"""
-        organizations = set()
+        organizations = _get_all_parent_organizations(self)
 
         if self.organization:
             organizations.add(self.organization)
-            organizations.update(_get_all_parent_organizations(self))
 
         return organizations
 

--- a/hours/models.py
+++ b/hours/models.py
@@ -180,6 +180,18 @@ class DataSource(SoftDeletableModel, TimeStampedModel):
         return self.id
 
 
+def _get_all_parent_organizations(resource):
+    parents = resource.parents.all()
+    if not parents:
+        return set()
+
+    result = set([parent.organization for parent in parents])
+    for parent in parents:
+        result.update(_get_all_parent_organizations(parent))
+
+    return result
+
+
 class Resource(SoftDeletableModel, TimeStampedModel):
     name = models.CharField(
         verbose_name=_("Name"), max_length=255, null=True, blank=True
@@ -257,6 +269,16 @@ class Resource(SoftDeletableModel, TimeStampedModel):
         }
 
         return processed_opening_hours
+
+    def get_organizations(self):
+        """Returns the resources and its parents organizations"""
+        organizations = set()
+
+        if self.organization:
+            organizations.add(self.organization)
+            organizations.update(_get_all_parent_organizations(self))
+
+        return organizations
 
 
 class ResourceOrigin(models.Model):

--- a/hours/permissions.py
+++ b/hours/permissions.py
@@ -1,0 +1,42 @@
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+from hours.models import DatePeriod, Resource, Rule, TimeSpan
+
+
+class ReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        return request.method in SAFE_METHODS
+
+    def has_object_permission(self, request, view, obj):
+        return request.method in SAFE_METHODS
+
+
+class IsMemberOrAdminOfOrganization(BasePermission):
+    def has_permission(self, request, view):
+        # Create permission is checked separately in the views
+        return bool(
+            request.method in SAFE_METHODS
+            or request.user
+            and request.user.is_authenticated
+        )
+
+    def has_object_permission(self, request, view, obj):
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        if request.user.is_superuser:
+            return True
+
+        users_organizations = request.user.get_all_organizations()
+
+        obj_organizations = set()
+        if isinstance(obj, Resource):
+            obj_organizations = obj.get_organizations()
+
+        if isinstance(obj, DatePeriod):
+            obj_organizations = obj.resource.get_organizations()
+
+        if isinstance(obj, (Rule, TimeSpan)):
+            obj_organizations = obj.group.period.resource.get_organizations()
+
+        return bool(users_organizations.intersection(obj_organizations))

--- a/hours/serializers.py
+++ b/hours/serializers.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext_lazy as _
 from django_orghierarchy.models import Organization
 from drf_writable_nested import WritableNestedModelSerializer
 from enumfields.drf import EnumField, EnumSupportSerializerMixin
@@ -5,6 +6,7 @@ from modeltranslation import settings as mt_settings
 from modeltranslation.translator import NotRegistered, translator
 from modeltranslation.utils import get_language
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from users.serializers import UserSerializer
 
@@ -126,7 +128,35 @@ class ResourceSerializer(
             "extra_data",
         ]
 
-        read_only_fields = ["parents", "last_modified_by"]
+        read_only_fields = ["last_modified_by"]
+        extra_kwargs = {"parents": {"required": False}}
+
+    def validate(self, attrs):
+        """Validate that the user is a member or admin of at least one of the
+        immediate parent resources organizations"""
+        result = super().validate(attrs)
+
+        if not self.context.get("request"):
+            return result
+
+        user = self.context["request"].user
+
+        if not user.is_superuser and result.get("parents"):
+            users_organizations = user.get_all_organizations()
+            if not any(
+                [
+                    parent.organization in users_organizations
+                    for parent in result.get("parents")
+                ]
+            ):
+                raise ValidationError(
+                    detail=_(
+                        "Cannot create or edit sub resources of a resource "
+                        "in an organisation the user is not part of "
+                    )
+                )
+
+        return result
 
 
 class TimeSpanSerializer(

--- a/hours/serializers.py
+++ b/hours/serializers.py
@@ -108,7 +108,6 @@ class ResourceSerializer(
     TranslationSerializerMixin, EnumSupportSerializerMixin, serializers.ModelSerializer
 ):
     last_modified_by = UserSerializer(read_only=True)
-    organization = OrganizationSerializer(read_only=True)
     origins = ResourceOriginSerializer(many=True, required=False, allow_null=True)
 
     class Meta:

--- a/hours/tests/test_api_permissions.py
+++ b/hours/tests/test_api_permissions.py
@@ -1,0 +1,972 @@
+import json
+
+import pytest
+from django.core.serializers.json import DjangoJSONEncoder
+from django.urls import reverse
+
+from hours.models import (
+    DatePeriod,
+    Resource,
+    Rule,
+    TimeSpan,
+    _get_all_parent_organizations,
+)
+
+
+#
+# Resource
+#
+@pytest.mark.django_db
+def test_create_resource_anonymous(api_client):
+    url = reverse("resource-list")
+
+    data = {"name": "Test name"}
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_resource_authenticated_no_org(user, api_client):
+    api_client.force_authenticate(user=user)
+
+    url = reverse("resource-list")
+
+    data = {"name": "Test name"}
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_resource_authenticated_has_org(
+    organization_factory, data_source, user, api_client
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+
+    organization.regular_users.add(user)
+    api_client.force_authenticate(user=user)
+
+    url = reverse("resource-list")
+
+    data = {
+        "name": "Test name",
+        "organization": organization.id,
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_resource_authenticated_different_org(
+    organization_factory, data_source, user, api_client
+):
+    organization1 = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+
+    organization2 = organization_factory(
+        origin_id=23456,
+        data_source=data_source,
+        name="Test organization",
+    )
+
+    organization1.regular_users.add(user)
+    api_client.force_authenticate(user=user)
+
+    url = reverse("resource-list")
+
+    data = {
+        "name": "Test name",
+        "organization": organization2.id,
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_resource_anonymous(resource, api_client):
+    original_name = resource.name
+
+    url = reverse("resource-detail", kwargs={"pk": resource.id})
+
+    data = {"name": "New name"}
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    resource = Resource.objects.get(id=resource.id)
+
+    assert resource.name == original_name
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_resource_authenticated_no_org_permission(
+    resource, data_source, organization_factory, user, api_client
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    original_name = resource.name
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("resource-detail", kwargs={"pk": resource.id})
+
+    data = {"name": "New name"}
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    resource = Resource.objects.get(id=resource.id)
+
+    assert resource.name == original_name
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_resource_authenticated_has_org_permission(
+    resource, data_source, organization_factory, user, api_client
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    organization.regular_users.add(user)
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("resource-detail", kwargs={"pk": resource.id})
+
+    data = {"name": "New name"}
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    resource = Resource.objects.get(id=resource.id)
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert resource.name == "New name"
+
+
+@pytest.mark.django_db
+def test_get_all_parent_organizations(
+    resource_factory, data_source, organization_factory
+):
+    #         resource A
+    #         org 1
+    #             |
+    #      +------+------+
+    #      |             |
+    # resource B     resource C
+    # org 2          org 3
+    #      |             |
+    #      +------+------+
+    #             |
+    #         resource D
+    #         org 4
+    org1 = organization_factory(
+        origin_id=1,
+        data_source=data_source,
+        name="Org 1",
+    )
+    org2 = organization_factory(
+        origin_id=2,
+        data_source=data_source,
+        name="Org 2",
+    )
+    org3 = organization_factory(
+        origin_id=3,
+        data_source=data_source,
+        name="Org 3",
+    )
+    org4 = organization_factory(
+        origin_id=4,
+        data_source=data_source,
+        name="Org 4",
+    )
+
+    resource_a = resource_factory(name="Resource A", organization=org1)
+    resource_b = resource_factory(name="Resource B", organization=org2)
+    resource_b.parents.add(resource_a)
+    resource_c = resource_factory(name="Resource C", organization=org3)
+    resource_c.parents.add(resource_a)
+    resource_d = resource_factory(name="Resource D", organization=org4)
+    resource_d.parents.add(resource_b)
+    resource_d.parents.add(resource_c)
+
+    assert _get_all_parent_organizations(resource_d) == {org1, org2, org3}
+
+
+#
+# DatePeriod
+#
+@pytest.mark.django_db
+def test_create_date_period_anonymous(api_client):
+    url = reverse("date_period-list")
+
+    data = {"name": "Date period name"}
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_date_period_authenticated_no_org_in_resource(
+    api_client, resource, user
+):
+    api_client.force_authenticate(user=user)
+
+    url = reverse("date_period-list")
+
+    data = {
+        "name": "Date period name",
+        "resource": resource.id,
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_date_period_authenticated_no_org_permission(
+    api_client, organization_factory, data_source, resource, user
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("date_period-list")
+
+    data = {
+        "name": "Date period name",
+        "resource": resource.id,
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_date_period_authenticated_has_org_permission(
+    api_client, organization_factory, data_source, resource, user
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    organization.regular_users.add(user)
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("date_period-list")
+
+    data = {
+        "name": "Date period name",
+        "resource": resource.id,
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_date_period_anonymous(resource, date_period_factory, api_client):
+    date_period = date_period_factory(resource=resource)
+
+    original_name = date_period.name
+
+    url = reverse("date_period-detail", kwargs={"pk": date_period.id})
+
+    data = {"name": "New name"}
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    date_period = DatePeriod.objects.get(id=date_period.id)
+
+    assert date_period.name == original_name
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_date_period_authenticated_no_org_permission(
+    resource, data_source, organization_factory, date_period_factory, user, api_client
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    date_period = date_period_factory(resource=resource)
+
+    original_name = date_period.name
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("date_period-detail", kwargs={"pk": date_period.id})
+
+    data = {"name": "New name"}
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    date_period = DatePeriod.objects.get(id=date_period.id)
+
+    assert date_period.name == original_name
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_date_period_authenticated_has_org_permission(
+    resource, data_source, organization_factory, date_period_factory, user, api_client
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    date_period = date_period_factory(resource=resource)
+
+    organization.regular_users.add(user)
+    api_client.force_authenticate(user=user)
+
+    url = reverse("date_period-detail", kwargs={"pk": date_period.id})
+
+    data = {"name": "New name"}
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    date_period = DatePeriod.objects.get(id=date_period.id)
+
+    assert date_period.name == "New name"
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+#
+# Rule
+#
+@pytest.mark.django_db
+def test_create_rule_anonymous(api_client):
+    url = reverse("rule-list")
+
+    data = {"name": "Rule name"}
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_rule_authenticated_no_org_in_resource(
+    api_client, resource, date_period_factory, time_span_group_factory, user
+):
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("rule-list")
+
+    data = {
+        "name": "Rule name",
+        "group": time_span_group.id,
+        "context": "period",
+        "subject": "week",
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_rule_authenticated_no_org_permission(
+    api_client,
+    organization_factory,
+    data_source,
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    user,
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("rule-list")
+
+    data = {
+        "name": "Rule name",
+        "group": time_span_group.id,
+        "context": "period",
+        "subject": "week",
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_rule_authenticated_has_org_permission(
+    api_client,
+    organization_factory,
+    data_source,
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    user,
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+
+    organization.regular_users.add(user)
+    api_client.force_authenticate(user=user)
+
+    url = reverse("rule-list")
+
+    data = {
+        "name": "Rule name",
+        "group": time_span_group.id,
+        "context": "period",
+        "subject": "week",
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_rule_anonymous(
+    api_client, resource, date_period_factory, time_span_group_factory, rule_factory
+):
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+    rule = rule_factory(
+        name="Rule name", group=time_span_group, context="period", subject="week"
+    )
+
+    url = reverse("rule-detail", kwargs={"pk": rule.id})
+
+    data = {
+        "name": "New name",
+    }
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_rule_authenticated_no_org_permission(
+    api_client,
+    resource,
+    organization_factory,
+    data_source,
+    date_period_factory,
+    time_span_group_factory,
+    rule_factory,
+    user,
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+    rule = rule_factory(
+        name="Rule name", group=time_span_group, context="period", subject="week"
+    )
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("rule-detail", kwargs={"pk": rule.id})
+
+    data = {
+        "name": "New name",
+    }
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_rule_authenticated_has_org_permission(
+    api_client,
+    resource,
+    organization_factory,
+    data_source,
+    date_period_factory,
+    time_span_group_factory,
+    rule_factory,
+    user,
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+    rule = rule_factory(
+        name="Rule name", group=time_span_group, context="period", subject="week"
+    )
+
+    organization.regular_users.add(user)
+    api_client.force_authenticate(user=user)
+
+    url = reverse("rule-detail", kwargs={"pk": rule.id})
+
+    data = {
+        "name": "New name",
+    }
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    rule = Rule.objects.get(pk=rule.id)
+    assert rule.name == "New name"
+
+
+#
+# TimeSpan
+#
+@pytest.mark.django_db
+def test_create_time_span_anonymous(api_client):
+    url = reverse("time_spans-list")
+
+    data = {"name": "Time span name"}
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_time_span_authenticated_no_org_in_resource(
+    api_client, resource, date_period_factory, time_span_group_factory, user
+):
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("time_spans-list")
+
+    data = {
+        "name": "Time span name",
+        "group": time_span_group.id,
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_time_span_authenticated_no_org_permission(
+    api_client,
+    organization_factory,
+    data_source,
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    user,
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("time_spans-list")
+
+    data = {
+        "name": "Time span name",
+        "group": time_span_group.id,
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_create_time_span_authenticated_has_org_permission(
+    api_client,
+    organization_factory,
+    data_source,
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    user,
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+
+    organization.regular_users.add(user)
+    api_client.force_authenticate(user=user)
+
+    url = reverse("time_spans-list")
+
+    data = {
+        "name": "Time span name",
+        "group": time_span_group.id,
+    }
+
+    response = api_client.post(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_time_span_anonymous(
+    api_client,
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    time_span_factory,
+):
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+    time_span = time_span_factory(name="Time span name", group=time_span_group)
+
+    url = reverse("time_spans-detail", kwargs={"pk": time_span.id})
+
+    data = {
+        "name": "New name",
+    }
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_time_span_authenticated_no_org_permission(
+    api_client,
+    resource,
+    organization_factory,
+    data_source,
+    date_period_factory,
+    time_span_group_factory,
+    time_span_factory,
+    user,
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+    time_span = time_span_factory(name="Time span name", group=time_span_group)
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("time_spans-detail", kwargs={"pk": time_span.id})
+
+    data = {
+        "name": "New name",
+    }
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+@pytest.mark.django_db
+def test_update_time_span_authenticated_has_org_permission(
+    api_client,
+    resource,
+    organization_factory,
+    data_source,
+    date_period_factory,
+    time_span_group_factory,
+    time_span_factory,
+    user,
+):
+    organization = organization_factory(
+        origin_id=12345,
+        data_source=data_source,
+        name="Test organization",
+    )
+    resource.organization = organization
+    resource.save()
+
+    date_period = date_period_factory(resource=resource)
+    time_span_group = time_span_group_factory(period=date_period)
+    time_span = time_span_factory(name="Time span name", group=time_span_group)
+
+    organization.regular_users.add(user)
+    api_client.force_authenticate(user=user)
+
+    url = reverse("time_spans-detail", kwargs={"pk": time_span.id})
+
+    data = {
+        "name": "New name",
+    }
+
+    response = api_client.patch(
+        url,
+        data=json.dumps(data, cls=DjangoJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    time_span = TimeSpan.objects.get(pk=time_span.id)
+    assert time_span.name == "New name"

--- a/hours/tests/test_dateperiod_api.py
+++ b/hours/tests/test_dateperiod_api.py
@@ -11,7 +11,7 @@ from hours.models import DatePeriod
 
 
 @pytest.mark.django_db
-def test_create_date_period_no_time_span_groups(resource, api_client):
+def test_create_date_period_no_time_span_groups(resource, admin_client):
     url = reverse("date_period-list")
 
     data = {
@@ -24,7 +24,7 @@ def test_create_date_period_no_time_span_groups(resource, api_client):
         "override": "false",
     }
 
-    response = api_client.post(
+    response = admin_client.post(
         url,
         data=json.dumps(data, cls=DjangoJSONEncoder),
         content_type="application/json",
@@ -42,7 +42,7 @@ def test_create_date_period_no_time_span_groups(resource, api_client):
 
 
 @pytest.mark.django_db
-def test_create_date_period_one_time_span_group_one_time_span(resource, api_client):
+def test_create_date_period_one_time_span_group_one_time_span(resource, admin_client):
     url = reverse("date_period-list")
 
     data = {
@@ -65,7 +65,7 @@ def test_create_date_period_one_time_span_group_one_time_span(resource, api_clie
         ],
     }
 
-    response = api_client.post(
+    response = admin_client.post(
         url,
         data=json.dumps(data, cls=DjangoJSONEncoder),
         content_type="application/json",
@@ -94,7 +94,7 @@ def test_create_date_period_one_time_span_group_one_time_span(resource, api_clie
 
 @pytest.mark.django_db
 def test_create_date_period_one_time_span_group_one_time_span_one_rule(
-    resource, api_client
+    resource, admin_client
 ):
     url = reverse("date_period-list")
 
@@ -125,7 +125,7 @@ def test_create_date_period_one_time_span_group_one_time_span_one_rule(
         ],
     }
 
-    response = api_client.post(
+    response = admin_client.post(
         url,
         data=json.dumps(data, cls=DjangoJSONEncoder),
         content_type="application/json",
@@ -159,7 +159,7 @@ def test_create_date_period_one_time_span_group_one_time_span_one_rule(
 
 @pytest.mark.django_db
 def test_update_date_period_no_time_span_groups(
-    resource, date_period_factory, api_client
+    resource, date_period_factory, admin_client
 ):
     date_period = date_period_factory(
         resource=resource,
@@ -178,7 +178,7 @@ def test_update_date_period_no_time_span_groups(
         "end_date": "2020-11-30",
     }
 
-    response = api_client.patch(
+    response = admin_client.patch(
         url,
         data=json.dumps(data, cls=DjangoJSONEncoder),
         content_type="application/json",
@@ -202,7 +202,7 @@ def test_update_date_period_keep_one_time_span(
     date_period_factory,
     time_span_group_factory,
     time_span_factory,
-    api_client,
+    admin_client,
 ):
     date_period = date_period_factory(
         resource=resource,
@@ -230,7 +230,7 @@ def test_update_date_period_keep_one_time_span(
         "end_date": "2020-11-30",
     }
 
-    response = api_client.patch(
+    response = admin_client.patch(
         url,
         data=json.dumps(data, cls=DjangoJSONEncoder),
         content_type="application/json",
@@ -259,7 +259,7 @@ def test_update_date_period_add_one_time_span(
     date_period_factory,
     time_span_group_factory,
     time_span_factory,
-    api_client,
+    admin_client,
 ):
     date_period = date_period_factory(
         resource=resource,
@@ -299,7 +299,7 @@ def test_update_date_period_add_one_time_span(
         ],
     }
 
-    response = api_client.patch(
+    response = admin_client.patch(
         url,
         data=json.dumps(data, cls=DjangoJSONEncoder),
         content_type="application/json",
@@ -327,7 +327,7 @@ def test_update_date_period_add_one_time_span(
 
 
 @pytest.mark.django_db
-def test_create_time_span_no_group(resource, api_client):
+def test_create_time_span_no_group(resource, admin_client):
     url = reverse("time_spans-list")
 
     data = {
@@ -338,7 +338,7 @@ def test_create_time_span_no_group(resource, api_client):
     # TODO: Change when viewsets changed to use different serializer for
     #       update and create.
     with pytest.raises(IntegrityError):
-        api_client.post(
+        admin_client.post(
             url,
             data=json.dumps(data, cls=DjangoJSONEncoder),
             content_type="application/json",

--- a/users/models.py
+++ b/users/models.py
@@ -9,3 +9,10 @@ class User(AbstractUser):
             return self.email
         else:
             return self.username
+
+    def get_all_organizations(self) -> set:
+        users_organizations = set()
+        users_organizations.update(self.admin_organizations.all())
+        users_organizations.update(self.organization_memberships.all())
+
+        return users_organizations


### PR DESCRIPTION
- Anyone can read everything
- Only users that are member or admin of a resources organization
  can edit or create
- Superusers can edit everything

Refs HAUKI-181