### PR TITLE
Rename Hauki Signed Auth parameters to be more specific

### DIFF
--- a/hours/authentication.py
+++ b/hours/authentication.py
@@ -26,7 +26,11 @@ REQUIRED_AUTH_PARAM_NAMES = [
     "hsa_valid_until",
     "hsa_signature",
 ]
-OPTIONAL_AUTH_PARAM_NAMES = ["hsa_organization", "hsa_resource"]
+OPTIONAL_AUTH_PARAM_NAMES = [
+    "hsa_organization",
+    "hsa_resource",
+    "hsa_has_organization_rights",
+]
 
 
 def get_auth_params_from_authz_header(request) -> dict:

--- a/hours/authentication.py
+++ b/hours/authentication.py
@@ -20,13 +20,13 @@ from hours.models import DataSource, SignedAuthEntry, SignedAuthKey
 User = get_user_model()
 
 REQUIRED_AUTH_PARAM_NAMES = [
-    "source",
-    "username",
-    "created_at",
-    "valid_until",
-    "signature",
+    "hsa_source",
+    "hsa_username",
+    "hsa_created_at",
+    "hsa_valid_until",
+    "hsa_signature",
 ]
-OPTIONAL_AUTH_PARAM_NAMES = ["organization", "resource"]
+OPTIONAL_AUTH_PARAM_NAMES = ["hsa_organization", "hsa_resource"]
 
 
 def get_auth_params_from_authz_header(request) -> dict:
@@ -74,7 +74,7 @@ def join_params(params):
     fields_in_order = [
         i
         for i in (REQUIRED_AUTH_PARAM_NAMES + OPTIONAL_AUTH_PARAM_NAMES)
-        if i != "signature"
+        if i != "hsa_signature"
     ]
 
     return "".join([params.get(field_name, "") for field_name in fields_in_order])
@@ -111,7 +111,7 @@ def validate_params_and_signature(params) -> bool:
 
     try:
         signed_auth_key = SignedAuthKey.objects.get(
-            Q(data_source__id=params["source"])
+            Q(data_source__id=params["hsa_source"])
             & Q(valid_after__lt=now)
             & (Q(valid_until__isnull=True) | Q(valid_until__gt=now))
         )
@@ -122,28 +122,28 @@ def validate_params_and_signature(params) -> bool:
         signed_auth_key.signing_key, join_params(params)
     )
 
-    if not compare_signatures(params["signature"], calculated_signature):
-        raise SignatureValidationError(_("Invalid signature"))
+    if not compare_signatures(params["hsa_signature"], calculated_signature):
+        raise SignatureValidationError(_("Invalid hsa_signature"))
 
     try:
-        created_at = parse(params["created_at"])
+        created_at = parse(params["hsa_created_at"])
         try:
             if created_at > timezone.now():
-                raise SignatureValidationError(_("Invalid created_at"))
+                raise SignatureValidationError(_("Invalid hsa_created_at"))
         except TypeError:
-            raise SignatureValidationError(_("Invalid created_at"))
+            raise SignatureValidationError(_("Invalid hsa_created_at"))
     except ValueError:
-        raise SignatureValidationError(_("Invalid created_at"))
+        raise SignatureValidationError(_("Invalid hsa_created_at"))
 
     try:
-        valid_until = parse(params["valid_until"])
+        valid_until = parse(params["hsa_valid_until"])
         try:
             if valid_until < timezone.now():
-                raise SignatureValidationError(_("Invalid valid_until"))
+                raise SignatureValidationError(_("Invalid hsa_valid_until"))
         except TypeError:
-            raise SignatureValidationError(_("Invalid valid_until"))
+            raise SignatureValidationError(_("Invalid hsa_valid_until"))
     except ValueError:
-        raise SignatureValidationError(_("Invalid valid_until"))
+        raise SignatureValidationError(_("Invalid hsa_valid_until"))
 
     return True
 
@@ -161,7 +161,7 @@ class HaukiSignedAuthentication(BaseAuthentication):
             raise exceptions.AuthenticationFailed(str(e))
 
         if SignedAuthEntry.objects.filter(
-            signature=params["signature"], invalidated_at__isnull=False
+            signature=params["hsa_signature"], invalidated_at__isnull=False
         ).exists():
             raise exceptions.AuthenticationFailed(_("Signature has been invalidated"))
 
@@ -169,23 +169,23 @@ class HaukiSignedAuthentication(BaseAuthentication):
         #       to users initially from the same integration. Also Only allow
         #       using organisations from the same integration.
         try:
-            user = User.objects.get(username=params["username"])
+            user = User.objects.get(username=params["hsa_username"])
         except User.DoesNotExist:
             user = User()
             user.set_unusable_password()
-            user.username = params["username"]
+            user.username = params["hsa_username"]
             user.save()
 
         if not user.is_active:
             raise exceptions.AuthenticationFailed(_("User inactive or deleted."))
 
-        if params.get("organization"):
+        if params.get("hsa_organization"):
             try:
-                organization = Organization.objects.get(id=params["organization"])
+                organization = Organization.objects.get(id=params["hsa_organization"])
 
                 # Allow joining users only to organizations that are from
                 # the same data source
-                data_source = DataSource.objects.get(id=params["source"])
+                data_source = DataSource.objects.get(id=params["hsa_source"])
                 if data_source == organization.data_source:
                     users_organizations = user.organization_memberships.all()
 

--- a/hours/tests/test_hauki_signed_auth.py
+++ b/hours/tests/test_hauki_signed_auth.py
@@ -27,16 +27,16 @@ def test_get_auth_required_header_invalid_signature(
 
     authz_string = (
         "haukisigned"
-        " source=" + data_source.id + "&username=test_user"
-        "&created_at=2020-10-01T06%3A35%3A00.917Z"
-        "&valid_until=2020-11-01T06%3A45%3A00.917Z"
-        "&signature=invalid_signature"
+        " hsa_source=" + data_source.id + "&hsa_username=test_user"
+        "&hsa_created_at=2020-10-01T06%3A35%3A00.917Z"
+        "&hsa_valid_until=2020-11-01T06%3A45%3A00.917Z"
+        "&hsa_signature=invalid_signature"
     )
 
     response = api_client.get(url, HTTP_AUTHORIZATION=authz_string)
 
     assert response.status_code == 403
-    assert str(response.data["detail"]) == "Invalid signature"
+    assert str(response.data["detail"]) == "Invalid hsa_signature"
 
 
 @pytest.mark.django_db
@@ -48,23 +48,23 @@ def test_get_auth_required_header_invalid_created_at(
     url = reverse("auth_required_test-list")
 
     data = {
-        "source": data_source.id,
-        "username": "test_user",
-        "created_at": "2030-01-01T10:10:10.000Z",
-        "valid_until": "2030-01-01T10:20:10.000Z",
+        "hsa_source": data_source.id,
+        "hsa_username": "test_user",
+        "hsa_created_at": "2030-01-01T10:10:10.000Z",
+        "hsa_valid_until": "2030-01-01T10:20:10.000Z",
     }
 
     source_string = join_params(data)
     signature = calculate_signature(signed_auth_key.signing_key, source_string)
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     response = api_client.get(url, HTTP_AUTHORIZATION=authz_string)
 
     assert response.status_code == 403
-    assert str(response.data["detail"]) == "Invalid created_at"
+    assert str(response.data["detail"]) == "Invalid hsa_created_at"
 
 
 @pytest.mark.django_db
@@ -76,23 +76,23 @@ def test_get_auth_required_header_invalid_valid_until(
     url = reverse("auth_required_test-list")
 
     data = {
-        "source": data_source.id,
-        "username": "test_user",
-        "created_at": "2020-01-01T10:10:10.000Z",
-        "valid_until": "2000-01-01T10:20:10.000Z",
+        "hsa_source": data_source.id,
+        "hsa_username": "test_user",
+        "hsa_created_at": "2020-01-01T10:10:10.000Z",
+        "hsa_valid_until": "2000-01-01T10:20:10.000Z",
     }
 
     source_string = join_params(data)
     signature = calculate_signature(signed_auth_key.signing_key, source_string)
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     response = api_client.get(url, HTTP_AUTHORIZATION=authz_string)
 
     assert response.status_code == 403
-    assert str(response.data["detail"]) == "Invalid valid_until"
+    assert str(response.data["detail"]) == "Invalid hsa_valid_until"
 
 
 @pytest.mark.django_db
@@ -106,17 +106,17 @@ def test_get_auth_required_header_authenticated(
     now = datetime.datetime.utcnow()
 
     data = {
-        "source": data_source.id,
-        "username": "test_user",
-        "created_at": now.isoformat() + "Z",
-        "valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_source": data_source.id,
+        "hsa_username": "test_user",
+        "hsa_created_at": now.isoformat() + "Z",
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
     }
 
     source_string = join_params(data)
     signature = calculate_signature(signed_auth_key.signing_key, source_string)
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     response = api_client.get(url, HTTP_AUTHORIZATION=authz_string)
@@ -138,17 +138,17 @@ def test_join_user_to_organization(
     now = datetime.datetime.utcnow()
 
     data = {
-        "source": data_source.id,
-        "username": "test_user",
-        "created_at": now.isoformat() + "Z",
-        "valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
-        "organization": org.id,
+        "hsa_source": data_source.id,
+        "hsa_username": "test_user",
+        "hsa_created_at": now.isoformat() + "Z",
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_organization": org.id,
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     response = api_client.get(url, HTTP_AUTHORIZATION=authz_string)
@@ -180,17 +180,17 @@ def test_join_user_to_organization_existing_user(
     now = datetime.datetime.utcnow()
 
     data = {
-        "source": data_source.id,
-        "username": user.username,
-        "created_at": now.isoformat() + "Z",
-        "valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
-        "organization": org.id,
+        "hsa_source": data_source.id,
+        "hsa_username": user.username,
+        "hsa_created_at": now.isoformat() + "Z",
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_organization": org.id,
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     response = api_client.get(url, HTTP_AUTHORIZATION=authz_string)
@@ -224,17 +224,17 @@ def test_join_user_to_organization_existing_user_and_organisation(
     now = datetime.datetime.utcnow()
 
     data = {
-        "source": data_source.id,
-        "username": user.username,
-        "created_at": now.isoformat() + "Z",
-        "valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
-        "organization": org.id,
+        "hsa_source": data_source.id,
+        "hsa_username": user.username,
+        "hsa_created_at": now.isoformat() + "Z",
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_organization": org.id,
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     response = api_client.get(url, HTTP_AUTHORIZATION=authz_string)
@@ -258,17 +258,17 @@ def test_join_user_to_organization_invalid_org(
     now = datetime.datetime.utcnow()
 
     data = {
-        "source": data_source.id,
-        "username": "test_user",
-        "created_at": now.isoformat() + "Z",
-        "valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
-        "organization": "test:2345",
+        "hsa_source": data_source.id,
+        "hsa_username": "test_user",
+        "hsa_created_at": now.isoformat() + "Z",
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_organization": "test:2345",
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     response = api_client.get(url, HTTP_AUTHORIZATION=authz_string)
@@ -297,17 +297,17 @@ def test_join_user_to_organization_wrong_data_source_org(
     now = datetime.datetime.utcnow()
 
     data = {
-        "source": data_source1.id,
-        "username": "test_user",
-        "created_at": now.isoformat() + "Z",
-        "valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
-        "organization": org.id,
+        "hsa_source": data_source1.id,
+        "hsa_username": "test_user",
+        "hsa_created_at": now.isoformat() + "Z",
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_organization": org.id,
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     response = api_client.get(url, HTTP_AUTHORIZATION=authz_string)
@@ -332,16 +332,16 @@ def test_signed_auth_entry_not_invalidated(
     valid_until = now + datetime.timedelta(minutes=10)
 
     data = {
-        "source": data_source.id,
-        "username": "test_user",
-        "created_at": now.isoformat() + "Z",
-        "valid_until": valid_until.isoformat() + "Z",
+        "hsa_source": data_source.id,
+        "hsa_username": "test_user",
+        "hsa_created_at": now.isoformat() + "Z",
+        "hsa_valid_until": valid_until.isoformat() + "Z",
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     # Check that auth works
@@ -377,16 +377,16 @@ def test_invalidate_signature_success_header_params(
     valid_until = now + datetime.timedelta(minutes=10)
 
     data = {
-        "source": data_source.id,
-        "username": "test_user",
-        "created_at": now.isoformat() + "Z",
-        "valid_until": valid_until.isoformat() + "Z",
+        "hsa_source": data_source.id,
+        "hsa_username": "test_user",
+        "hsa_created_at": now.isoformat() + "Z",
+        "hsa_valid_until": valid_until.isoformat() + "Z",
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     # Check that auth works
@@ -424,15 +424,15 @@ def test_invalidate_signature_success_query_params(
     now = datetime.datetime.utcnow()
 
     data = {
-        "source": data_source.id,
-        "username": "test_user",
-        "created_at": now.isoformat() + "Z",
-        "valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_source": data_source.id,
+        "hsa_username": "test_user",
+        "hsa_created_at": now.isoformat() + "Z",
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
 
-    authz_string = "?" + urllib.parse.urlencode({**data, "signature": signature})
+    authz_string = "?" + urllib.parse.urlencode({**data, "hsa_signature": signature})
 
     # Check that auth works
     response = api_client.get(f"{url}{authz_string}")
@@ -472,16 +472,16 @@ def test_invalidate_signature_invalid_params(
     now = datetime.datetime.utcnow()
 
     data = {
-        "source": data_source.id,
-        # username missing
-        "created_at": now.isoformat() + "Z",
-        "valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_source": data_source.id,
+        # hsa_username missing
+        "hsa_created_at": now.isoformat() + "Z",
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
 
     authz_string = "haukisigned " + urllib.parse.urlencode(
-        {**data, "signature": signature}
+        {**data, "hsa_signature": signature}
     )
 
     # Invalidate the signature


### PR DESCRIPTION
The param names (e.g. source, resource) were too generic. For example in the Date Period list the "resource"-filter clashed with the authentication parameter.

The new parameter names are "hsa_source", "hsa_username", "hsa_created_at", "hsa_valid_until", "hsa_signature", "hsa_organization", and "hsa_resource".