### PR TITLE
Hauki 258 filter by missing origin

### DIFF
--- a/hours/admin.py
+++ b/hours/admin.py
@@ -30,13 +30,31 @@ class ResourceOriginInline(admin.TabularInline):
     extra = 1
 
 
+class ChildResourceInline(admin.TabularInline):
+    verbose_name = _("Child")
+    verbose_name_plural = _("Children")
+    model = Resource.children.through
+    fk_name = "from_resource"
+    raw_id_fields = ("from_resource", "to_resource")
+    extra = 1
+
+
+class ParentResourceInline(admin.TabularInline):
+    verbose_name = _("Parent")
+    verbose_name_plural = _("Parents")
+    model = Resource.children.through
+    fk_name = "to_resource"
+    raw_id_fields = ("from_resource", "to_resource")
+    extra = 1
+
+
 class ResourceAdmin(HaukiModelAdmin):
     search_fields = ("name", "description")
     list_display = ("name", "resource_type", "is_public")
     list_filter = ("resource_type", "data_sources", "is_public")
     ordering = ("name",)
     raw_id_fields = ("children", "organization")
-    inlines = (ResourceOriginInline,)
+    inlines = (ResourceOriginInline, ParentResourceInline, ChildResourceInline)
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
@@ -51,6 +69,17 @@ class ResourceAdmin(HaukiModelAdmin):
             )
 
         return form
+
+    def save_related(self, request, form, formsets, change):
+        super().save_related(request, form, formsets, change)
+
+        if not change or not form.instance:
+            return
+
+        # Admin is not sending m2m_changed signals when saving the
+        # inline parent or child. We need to trigger the ancestry fields
+        # update manually.
+        form.instance.update_ancestry()
 
 
 class TimeSpanInline(admin.StackedInline):

--- a/hours/management/commands/update_resource_ancestry_fields.py
+++ b/hours/management/commands/update_resource_ancestry_fields.py
@@ -6,8 +6,14 @@ from hours.models import Resource
 class Command(BaseCommand):
     help = "Update child resource ancestry fields"
 
+    def add_arguments(self, parser):
+        parser.add_argument("resource_ids", nargs="+", type=int)
+
     def handle(self, *args, **options):
-        child_resources = Resource.objects.filter(parents__isnull=False).distinct()
+        if options["resource_ids"]:
+            child_resources = Resource.objects.filter(id__in=options["resource_ids"])
+        else:
+            child_resources = Resource.objects.filter(parents__isnull=False).distinct()
 
         for child_resource in child_resources:
             self.stdout.write(

--- a/hours/tests/test_new_models.py
+++ b/hours/tests/test_new_models.py
@@ -1415,16 +1415,6 @@ def test_resource_get_daily_opening_hours_multiple_overrides(
         full_day=False,
     )
 
-    print()
-    from pprint import pprint
-
-    pprint(
-        resource.get_daily_opening_hours(
-            datetime.date(year=2020, month=12, day=23),
-            datetime.date(year=2020, month=12, day=25),
-        )
-    )
-
     assert resource.get_daily_opening_hours(
         datetime.date(year=2020, month=12, day=23),
         datetime.date(year=2020, month=12, day=25),

--- a/hours/tests/test_resource_api.py
+++ b/hours/tests/test_resource_api.py
@@ -1,0 +1,502 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_list_resources_empty(admin_client):
+    url = reverse("resource-list")
+
+    response = admin_client.get(url)
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
+def test_list_resources_one_resource(admin_client, resource_factory):
+    resource = resource_factory()
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url)
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 1
+    assert response.data["results"][0]["id"] == resource.id
+
+
+@pytest.mark.django_db
+def test_list_resources_multiple_resources(admin_client, resource_factory):
+    resource = resource_factory()
+    resource2 = resource_factory()
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url)
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 2
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource.id, resource2.id}
+
+
+@pytest.mark.django_db
+def test_list_resources_data_source_filter_none_of_two_match(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+
+    resource_factory()
+    resource_factory()
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url, data={"data_source": data_source.id})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
+def test_list_resources_data_source_filter_one_of_two_match(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source)
+
+    resource_factory()
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url, data={"data_source": data_source.id})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 1
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource.id}
+
+
+@pytest.mark.django_db
+def test_list_resources_data_source_filter_two_of_two_match(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source)
+
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource2, data_source=data_source)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url, data={"data_source": data_source.id})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 2
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource.id, resource2.id}
+
+
+@pytest.mark.django_db
+def test_list_resources_origin_id_exists_filter_false_all_match(
+    admin_client, resource_factory
+):
+    resource = resource_factory()
+    resource2 = resource_factory()
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url, data={"origin_id_exists": False})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 2
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource.id, resource2.id}
+
+
+@pytest.mark.django_db
+def test_list_resources_origin_id_exists_filter_false_one_matches(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+
+    resource = resource_factory()
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource2, data_source=data_source)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url, data={"origin_id_exists": False})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 1
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource.id}
+
+
+@pytest.mark.django_db
+def test_list_resources_origin_id_exists_filter_false_none_match(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source)
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource2, data_source=data_source)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url, data={"origin_id_exists": False})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
+def test_list_resources_origin_id_exists_filter_true_all_match(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source)
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource2, data_source=data_source)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url, data={"origin_id_exists": True})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 2
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource.id, resource2.id}
+
+
+@pytest.mark.django_db
+def test_list_resources_origin_id_exists_filter_true_one_matches(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+
+    resource_factory()
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource2, data_source=data_source)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url, data={"origin_id_exists": True})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 1
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource2.id}
+
+
+@pytest.mark.django_db
+def test_list_resources_origin_id_exists_filter_true_none_match(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source_factory()
+
+    resource_factory()
+    resource_factory()
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(url, data={"origin_id_exists": True})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
+def test_list_resources_data_source_and_origin_id_exists_filter_none_match(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+    data_source2 = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source)
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource2, data_source=data_source)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(
+        url, data={"data_source": data_source2.id, "origin_id_exists": True}
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
+def test_list_resources_data_source_and_origin_id_exists_filter_all_match(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source)
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource2, data_source=data_source)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(
+        url, data={"data_source": data_source.id, "origin_id_exists": True}
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 2
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource.id, resource2.id}
+
+
+@pytest.mark.django_db
+def test_data_source_and_origin_id_exists_two_data_sources(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+    data_source2 = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source)
+    resource_origin_factory(resource=resource, data_source=data_source2)
+
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource2, data_source=data_source)
+    resource_origin_factory(resource=resource2, data_source=data_source2)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(
+        url, data={"data_source": data_source.id, "origin_id_exists": True}
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 2
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource.id, resource2.id}
+
+
+@pytest.mark.django_db
+def test_data_source_and_origin_id_exists_two_data_sources_on_other(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+    data_source2 = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source2)
+
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource2, data_source=data_source)
+    resource_origin_factory(resource=resource2, data_source=data_source2)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(
+        url, data={"data_source": data_source.id, "origin_id_exists": True}
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 1
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource2.id}
+
+
+@pytest.mark.django_db
+def test_data_source_and_origin_id_exists_false_two_data_sources_on_other(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+    data_source2 = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source2)
+
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource2, data_source=data_source)
+    resource_origin_factory(resource=resource2, data_source=data_source2)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(
+        url, data={"data_source": data_source.id, "origin_id_exists": False}
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
+def test_data_source_and_origin_id_exists_false_data_sources_in_parent(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+    data_source2 = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source)
+    resource_origin_factory(resource=resource, data_source=data_source2)
+
+    resource2 = resource_factory()
+    resource.children.add(resource2)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(
+        url, data={"data_source": data_source.id, "origin_id_exists": False}
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 1
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource2.id}
+
+
+@pytest.mark.django_db
+def test_data_source_and_origin_id_exists_false_different_data_source_in_child(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+    data_source2 = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source)
+    resource_origin_factory(resource=resource, data_source=data_source2)
+
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source2)
+    resource.children.add(resource2)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(
+        url, data={"data_source": data_source.id, "origin_id_exists": False}
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 1
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource2.id}
+
+
+@pytest.mark.django_db
+def test_data_source_and_origin_id_exists_true_different_data_source_in_child(
+    admin_client, data_source_factory, resource_factory, resource_origin_factory
+):
+    data_source = data_source_factory()
+    data_source2 = data_source_factory()
+
+    resource = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source)
+    resource_origin_factory(resource=resource, data_source=data_source2)
+
+    resource2 = resource_factory()
+    resource_origin_factory(resource=resource, data_source=data_source2)
+    resource.children.add(resource2)
+
+    url = reverse("resource-list")
+
+    response = admin_client.get(
+        url, data={"data_source": data_source.id, "origin_id_exists": True}
+    )
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["count"] == 1
+
+    resource_ids = {i["id"] for i in response.data["results"]}
+
+    assert resource_ids == {resource.id}


### PR DESCRIPTION
Adds ability to filter resources by DataSource. Also allows to filter Resources that have no origin id in any data source or in the provided data source.

Additionally
- adds parents and children inlines to the resource admin
- adds "resource_ids" optional argument to update_resource_ancestry_fields-command