### PR TITLE
Simple endpoint for checking if a resource is open right now

### DIFF
--- a/hours/enums.py
+++ b/hours/enums.py
@@ -26,6 +26,17 @@ class State(Enum):
         EXIT_ONLY = pgettext_lazy("State", "Exit only")
         WEATHER_PERMITTING = pgettext_lazy("State", "Weather permitting")
 
+    @classmethod
+    def open_states(cls):
+        return [
+            cls.OPEN,
+            cls.SELF_SERVICE,
+            cls.WITH_KEY,
+            cls.WITH_RESERVATION,
+            cls.WITH_KEY_AND_RESERVATION,
+            cls.ENTER_ONLY,
+        ]
+
 
 class ResourceType(Enum):
     UNIT = "unit"

--- a/hours/fields.py
+++ b/hours/fields.py
@@ -1,0 +1,19 @@
+from django.utils import timezone
+from pytz import InvalidTimeError, utc
+from rest_framework.fields import DateTimeField
+
+
+class TimezoneRetainingDateTimeField(DateTimeField):
+    def enforce_timezone(self, value):
+        field_timezone = getattr(self, "timezone", self.default_timezone())
+
+        if field_timezone is not None:
+            if timezone.is_aware(value):
+                return value
+            try:
+                return timezone.make_aware(value, field_timezone)
+            except InvalidTimeError:
+                self.fail("make_aware", timezone=field_timezone)
+        elif (field_timezone is None) and timezone.is_aware(value):
+            return timezone.make_naive(value, utc)
+        return value

--- a/hours/serializers.py
+++ b/hours/serializers.py
@@ -11,6 +11,7 @@ from timezone_field.rest_framework import TimeZoneSerializerField
 from users.serializers import UserSerializer
 
 from .enums import State
+from .fields import TimezoneRetainingDateTimeField
 from .models import (
     DataSource,
     DatePeriod,
@@ -337,7 +338,7 @@ class IsOpenNowSerializer(serializers.Serializer):
     matching_opening_hours = TimeElementSerializer(many=True)
 
     other_timezone = TimeZoneSerializerField(required=False)
-    other_timezone_time_now = serializers.CharField(required=False)
+    other_timezone_time_now = TimezoneRetainingDateTimeField(required=False)
     matching_opening_hours_in_other_tz = TimeElementSerializer(
         many=True, required=False
     )

--- a/hours/serializers.py
+++ b/hours/serializers.py
@@ -328,3 +328,18 @@ class ResourceDailyOpeningHoursSerializer(serializers.Serializer):
     origin_id = serializers.CharField(required=False)
     resource = ResourceSimpleSerializer()
     opening_hours = DailyOpeningHoursSerializer(many=True)
+
+
+class IsOpenNowSerializer(serializers.Serializer):
+    is_open = serializers.BooleanField()
+    resource_timezone = TimeZoneSerializerField(required=False)
+    resource_time_now = serializers.DateTimeField()
+    matching_opening_hours = TimeElementSerializer(many=True)
+
+    other_timezone = TimeZoneSerializerField(required=False)
+    other_timezone_time_now = serializers.CharField(required=False)
+    matching_opening_hours_in_other_tz = TimeElementSerializer(
+        many=True, required=False
+    )
+
+    resource = ResourceSerializer()

--- a/hours/tests/conftest.py
+++ b/hours/tests/conftest.py
@@ -55,6 +55,7 @@ class ResourceFactory(factory.django.DjangoModelFactory):
     name = factory.LazyAttribute(lambda x: faker.company())
     address = factory.LazyAttribute(lambda x: faker.address())
     is_public = True
+    timezone = "Europe/Helsinki"
 
     class Meta:
         model = Resource

--- a/hours/tests/test_is_open_now_api.py
+++ b/hours/tests/test_is_open_now_api.py
@@ -1,0 +1,239 @@
+import datetime
+
+import pytest
+from django.urls import reverse
+from freezegun import freeze_time
+
+from hours.enums import State, Weekday
+
+
+@pytest.mark.django_db
+def test_is_open_no_spans(admin_client, resource):
+    url = reverse("resource-is-open-now", kwargs={"pk": resource.id})
+
+    response = admin_client.get(url)
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["is_open"] is False
+    assert response.data["resource"]["id"] == resource.id
+    assert len(response.data["matching_opening_hours"]) == 0
+
+
+@pytest.mark.django_db
+def test_is_open_one_match(
+    admin_client,
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    time_span_factory,
+):
+    date_period = date_period_factory(
+        resource=resource,
+        name="Testperiod",
+        start_date=datetime.date(year=2021, month=1, day=1),
+        end_date=datetime.date(year=2021, month=1, day=31),
+    )
+
+    time_span_group = time_span_group_factory(period=date_period)
+
+    time_span_factory(
+        group=time_span_group,
+        start_time=datetime.time(hour=8, minute=0),
+        end_time=datetime.time(hour=16, minute=0),
+        resource_state=State.OPEN,
+    )
+
+    url = reverse("resource-is-open-now", kwargs={"pk": resource.id})
+
+    with freeze_time("2021-01-11 12:00:00+02:00"):
+        response = admin_client.get(url)
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["is_open"] is True
+    assert len(response.data["matching_opening_hours"]) == 1
+
+
+@pytest.mark.django_db
+def test_is_open_one_non_open(
+    admin_client,
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    time_span_factory,
+):
+    date_period = date_period_factory(
+        resource=resource,
+        name="Testperiod",
+        start_date=datetime.date(year=2021, month=1, day=1),
+        end_date=datetime.date(year=2021, month=1, day=31),
+    )
+
+    time_span_group = time_span_group_factory(period=date_period)
+
+    time_span_factory(
+        group=time_span_group,
+        start_time=datetime.time(hour=8, minute=0),
+        end_time=datetime.time(hour=16, minute=0),
+        resource_state=State.CLOSED,
+    )
+
+    url = reverse("resource-is-open-now", kwargs={"pk": resource.id})
+
+    with freeze_time("2021-01-11 12:00:00+02:00"):
+        response = admin_client.get(url)
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["is_open"] is False
+    assert len(response.data["matching_opening_hours"]) == 0
+
+
+@pytest.mark.django_db
+def test_is_open_one_matching_and_non_open(
+    admin_client,
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    time_span_factory,
+):
+    date_period = date_period_factory(
+        resource=resource,
+        name="Testperiod",
+        start_date=datetime.date(year=2021, month=1, day=1),
+        end_date=datetime.date(year=2021, month=1, day=31),
+    )
+
+    time_span_group = time_span_group_factory(period=date_period)
+
+    time_span_factory(
+        group=time_span_group,
+        start_time=datetime.time(hour=8, minute=0),
+        end_time=datetime.time(hour=16, minute=0),
+        resource_state=State.OPEN,
+    )
+
+    time_span_factory(
+        group=time_span_group,
+        start_time=datetime.time(hour=8, minute=0),
+        end_time=datetime.time(hour=16, minute=0),
+        resource_state=State.CLOSED,
+    )
+
+    url = reverse("resource-is-open-now", kwargs={"pk": resource.id})
+
+    with freeze_time("2021-01-11 12:00:00+02:00"):
+        response = admin_client.get(url)
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["is_open"] is True
+    assert len(response.data["matching_opening_hours"]) == 1
+
+
+@pytest.mark.django_db
+def test_is_open_one_match_with_other_timezone(
+    admin_client,
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    time_span_factory,
+):
+    date_period = date_period_factory(
+        resource=resource,
+        name="Testperiod",
+        start_date=datetime.date(year=2021, month=1, day=1),
+        end_date=datetime.date(year=2021, month=1, day=31),
+    )
+
+    time_span_group = time_span_group_factory(period=date_period)
+
+    time_span_factory(
+        group=time_span_group,
+        start_time=datetime.time(hour=8, minute=0),
+        end_time=datetime.time(hour=16, minute=0),
+        resource_state=State.OPEN,
+    )
+
+    url = reverse("resource-is-open-now", kwargs={"pk": resource.id})
+
+    with freeze_time("2021-01-11 12:00:00+02:00"):
+        response = admin_client.get(url, data={"timezone": "UTC"})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["is_open"] is True
+    assert len(response.data["matching_opening_hours"]) == 1
+    assert len(response.data["matching_opening_hours_in_other_tz"]) == 1
+
+    te = response.data["matching_opening_hours_in_other_tz"][0]
+    assert te["start_time"] == "06:00:00"
+    assert te["end_time"] == "14:00:00"
+
+    assert response.data["resource_time_now"] == "2021-01-11T12:00:00+02:00"
+    assert response.data["resource_timezone"] == "Europe/Helsinki"
+    assert response.data["other_timezone_time_now"] == "2021-01-11T10:00:00Z"
+    assert response.data["other_timezone"] == "UTC"
+
+
+@pytest.mark.django_db
+def test_is_open_one_match_timezone_day_difference(
+    admin_client,
+    resource,
+    date_period_factory,
+    time_span_group_factory,
+    time_span_factory,
+):
+    date_period = date_period_factory(
+        resource=resource,
+        name="Testperiod",
+        start_date=datetime.date(year=2021, month=1, day=1),
+        end_date=datetime.date(year=2021, month=1, day=31),
+    )
+
+    time_span_group = time_span_group_factory(period=date_period)
+
+    time_span_factory(
+        group=time_span_group,
+        start_time=datetime.time(hour=0, minute=0),
+        end_time=datetime.time(hour=6, minute=0),
+        resource_state=State.OPEN,
+        weekdays=[Weekday.TUESDAY],
+    )
+
+    url = reverse("resource-is-open-now", kwargs={"pk": resource.id})
+
+    with freeze_time("2021-01-11 23:00:00+00:00"):
+        response = admin_client.get(url, data={"timezone": "UTC"})
+
+    assert response.status_code == 200, "{} {}".format(
+        response.status_code, response.data
+    )
+
+    assert response.data["is_open"] is True
+    assert len(response.data["matching_opening_hours"]) == 1
+    assert len(response.data["matching_opening_hours_in_other_tz"]) == 1
+
+    te = response.data["matching_opening_hours"][0]
+    assert te["start_time"] == "00:00:00"
+    assert te["end_time"] == "06:00:00"
+
+    other_te = response.data["matching_opening_hours_in_other_tz"][0]
+    assert other_te["start_time"] == "22:00:00"
+    assert other_te["end_time"] == "04:00:00"
+
+    assert response.data["resource_time_now"] == "2021-01-12T01:00:00+02:00"
+    assert response.data["resource_timezone"] == "Europe/Helsinki"
+    assert response.data["other_timezone_time_now"] == "2021-01-11T23:00:00Z"
+    assert response.data["other_timezone"] == "UTC"

--- a/hours/tests/test_translation_serializer.py
+++ b/hours/tests/test_translation_serializer.py
@@ -20,7 +20,7 @@ def test_to_representation(resource, settings):
         "resource_type": "unit",
         "origins": [],
         "is_public": True,
-        "timezone": settings.RESOURCE_DEFAULT_TIMEZONE,
+        "timezone": "Europe/Helsinki",
     }
 
     assert serializer.data == expected_data

--- a/hours/viewsets.py
+++ b/hours/viewsets.py
@@ -2,8 +2,11 @@ import datetime
 from operator import itemgetter
 from typing import Tuple
 
+import pytz
+from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from django.http import Http404
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_filters.rest_framework import DjangoFilterBackend
 from django_orghierarchy.models import Organization
@@ -18,8 +21,9 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from .enums import State
 from .filters import DatePeriodFilter, TimeSpanFilter, parse_maybe_relative_date_string
-from .models import DatePeriod, Resource, Rule, TimeSpan
+from .models import DatePeriod, Resource, Rule, TimeElement, TimeSpan
 from .permissions import (
     IsMemberOrAdminOfOrganization,
     ReadOnlyPublic,
@@ -28,6 +32,7 @@ from .permissions import (
 from .serializers import (
     DailyOpeningHoursSerializer,
     DatePeriodSerializer,
+    IsOpenNowSerializer,
     OrganizationSerializer,
     ResourceDailyOpeningHoursSerializer,
     ResourceSerializer,
@@ -275,6 +280,124 @@ class ResourceViewSet(
         opening_hours_list.sort(key=itemgetter("date"))
 
         serializer = DailyOpeningHoursSerializer(opening_hours_list, many=True)
+
+        return Response(serializer.data)
+
+    @action(detail=True)
+    def is_open_now(self, request, pk=None):
+        resource = self.get_object()
+        open_states = State.open_states()
+        time_now = timezone.now()
+
+        tz = resource.timezone
+        if not tz:
+            tz = pytz.timezone(settings.RESOURCE_DEFAULT_TIMEZONE)
+            if not tz:
+                tz = pytz.timezone("Europe/Helsinki")
+
+        resource_time_now = time_now.astimezone(tz)
+
+        other_tz = None
+        if request.query_params.get("timezone"):
+            try:
+                other_tz = pytz.timezone(request.query_params.get("timezone"))
+            except pytz.exceptions.UnknownTimeZoneError:
+                raise APIException("Unknown timezone")
+
+        opening_hours = resource.get_daily_opening_hours(
+            resource_time_now.date(), resource_time_now.date()
+        ).get(
+            datetime.date(
+                year=resource_time_now.year,
+                month=resource_time_now.month,
+                day=resource_time_now.day,
+            ),
+            [],
+        )
+
+        matching_opening_hours = []
+        matching_opening_hours_other_tz = []
+
+        for opening_hour in opening_hours:
+            start_datetime = tz.localize(
+                datetime.datetime(
+                    year=resource_time_now.year,
+                    month=resource_time_now.month,
+                    day=resource_time_now.day,
+                    hour=opening_hour.start_time.hour,
+                    minute=opening_hour.start_time.minute,
+                    second=opening_hour.start_time.second,
+                )
+            )
+
+            # TODO: inter day check when the branch is merged
+            # if opening_hour.is_inter_day():
+            #     tomorrow = resource_time_now + relativedelta(days=1)
+            #     end_datetime = tz.localize(datetime.datetime(
+            #         year=tomorrow.year,
+            #         month=tomorrow.month,
+            #         day=tomorrow.day,
+            #         hour=opening_hour.end_time.hour,
+            #         minute=opening_hour.end_time.minute,
+            #         second=opening_hour.end_time.second
+            #     ))
+            # else:
+            end_datetime = tz.localize(
+                datetime.datetime(
+                    year=resource_time_now.year,
+                    month=resource_time_now.month,
+                    day=resource_time_now.day,
+                    hour=opening_hour.end_time.hour,
+                    minute=opening_hour.end_time.minute,
+                    second=opening_hour.end_time.second,
+                )
+            )
+
+            if (
+                start_datetime <= resource_time_now <= end_datetime
+                and opening_hour.resource_state in open_states
+            ):
+                matching_opening_hours.append(opening_hour)
+
+                if other_tz:
+                    other_timezone_start_datetime = start_datetime.astimezone(other_tz)
+                    other_timezone_end_datetime = end_datetime.astimezone(other_tz)
+
+                    matching_opening_hours_other_tz.append(
+                        TimeElement(
+                            start_time=other_timezone_start_datetime.time(),
+                            end_time=other_timezone_end_datetime.time(),
+                            resource_state=opening_hour.resource_state,
+                            override=opening_hour.override,
+                            full_day=opening_hour.full_day,
+                            name=opening_hour.name,
+                            description=opening_hour.description,
+                            periods=opening_hour.periods,
+                        )
+                    )
+
+        other_timezone_time_now = resource_time_now.astimezone(other_tz)
+
+        data = {
+            "is_open": bool(matching_opening_hours),
+            "resource_timezone": tz,
+            "resource_time_now": resource_time_now,
+            "matching_opening_hours": matching_opening_hours,
+            "resource": resource,
+        }
+
+        if other_tz:
+            data = {
+                **data,
+                "other_timezone": other_tz,
+                # Return the time in the other timezone as string as the DateTimeField
+                # would change the timezone.
+                # TODO: use the same output format as in the DateTimeField
+                "other_timezone_time_now": other_timezone_time_now,
+                "matching_opening_hours_in_other_tz": matching_opening_hours_other_tz,
+            }
+
+        serializer = IsOpenNowSerializer(data)
 
         return Response(serializer.data)
 

--- a/hours/viewsets.py
+++ b/hours/viewsets.py
@@ -390,9 +390,6 @@ class ResourceViewSet(
             data = {
                 **data,
                 "other_timezone": other_tz,
-                # Return the time in the other timezone as string as the DateTimeField
-                # would change the timezone.
-                # TODO: use the same output format as in the DateTimeField
                 "other_timezone_time_now": other_timezone_time_now,
                 "matching_opening_hours_in_other_tz": matching_opening_hours_other_tz,
             }


### PR DESCRIPTION
Adds a /v1/resource/[resource_id]/is_open_now endpoint. Supports an optional "timezone" parameter for showing the opening hours in that timezone too.

A resource is considered open if there is a matching time span with one of these states:

OPEN, SELF_SERVICE, WITH_KEY, WITH_RESERVATION, WITH_KEY_AND_RESERVATION, ENTER_ONLY

Might want to think about those further.

~TODO:~
~Tests~
~Proper formatting for the "other_timezone_time_now"-field~

Example response without the other timezone:

```json
{
    "is_open": true,
    "resource_timezone": "Europe/Helsinki",
    "resource_time_now": "2021-01-05T15:44:02.799739+02:00",
    "matching_opening_hours": [
        {
            "name": "",
            "description": "",
            "start_time": "13:00:00",
            "end_time": "20:00:00",
            "resource_state": "open",
            "full_day": false,
            "periods": [
                9694
            ]
        }
    ],
    "resource": {
        "id": 95864,
        "name": {
            "fi": "Joku resurssi",
            "sv": null,
            "en": null
        },
        "description": {
            "fi": "Joku resurssikuvaus",
            "sv": null,
            "en": null
        },
        "address": {
            "fi": null,
            "sv": null,
            "en": null
        },
        "resource_type": "unit",
        "children": [],
        "parents": [],
        "organization": null,
        "origins": [],
        "last_modified_by": {
            "id": 1,
            "first_name": "",
            "last_name": ""
        },
        "extra_data": null,
        "is_public": true,
        "timezone": "Europe/Helsinki"
    }
}
```

Example response with "?timezone=UTC":

```json
{
    "is_open": true,
    "resource_timezone": "Europe/Helsinki",
    "resource_time_now": "2021-01-05T15:43:17.241624+02:00",
    "matching_opening_hours": [
        {
            "name": "",
            "description": "",
            "start_time": "13:00:00",
            "end_time": "20:00:00",
            "resource_state": "open",
            "full_day": false,
            "periods": [
                9694
            ]
        }
    ],
    "other_timezone": "UTC",
    "other_timezone_time_now": "2021-01-05 13:43:17.241624+00:00",
    "matching_opening_hours_in_other_tz": [
        {
            "name": "",
            "description": "",
            "start_time": "11:00:00",
            "end_time": "18:00:00",
            "resource_state": "open",
            "full_day": false,
            "periods": [
                9694
            ]
        }
    ],
    "resource": {
        "id": 95864,
        "name": {
            "fi": "Joku resurssi",
            "sv": null,
            "en": null
        },
        "description": {
            "fi": "Joku resurssikuvaus",
            "sv": null,
            "en": null
        },
        "address": {
            "fi": null,
            "sv": null,
            "en": null
        },
        "resource_type": "unit",
        "children": [],
        "parents": [],
        "organization": null,
        "origins": [],
        "last_modified_by": {
            "id": 1,
            "first_name": "",
            "last_name": ""
        },
        "extra_data": null,
        "is_public": true,
        "timezone": "Europe/Helsinki"
    }
}
```

