### PR TITLE
Defer updating denormalized data when updating date period

### DIFF
--- a/hours/viewsets.py
+++ b/hours/viewsets.py
@@ -709,6 +709,10 @@ class DatePeriodViewSet(
             )
         return super().list(request, *args, **kwargs)
 
+    def update(self, request, *args, **kwargs):
+        with DeferUpdatingDenormalizedDatePeriodData():
+            return super().update(request, *args, **kwargs)
+
 
 @extend_schema_view(
     list=extend_schema(summary="List Rules"),


### PR DESCRIPTION
Time span data in the denormalized content didn't get updated when date period
was updated via api.

That was because when saving nested serializers, the parent instance gets saved
first and the time spans were updated to the date period later. Which in turn
doesn't trigger denormalized data update because there are no suitable signals
to use when Django updates one-to-many relations.