### PR TITLE
Increase uwsgi buffer-size

### DIFF
--- a/deploy/uwsgi.yml
+++ b/deploy/uwsgi.yml
@@ -11,6 +11,6 @@ uwsgi:
   reload-on-rss: 300
   # Allow large image uploads
   # chunked-input-limit: 10485760
-  buffer-size: 32768
+  buffer-size: 65535
   http: :8000
   static-map: /static=/srv/static


### PR DESCRIPTION
We seems to be facing `Connection reset by peer` from time to time resulting to a Bad Gateway 502 meaning timeout. Thinking of experimenting with increasing the value for the buffer-size. 

Logs: https://kibana-openshift-logging.apps.arodevtest.hel.fi/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now%2Fd,mode:quick,to:now))&_a=(columns:!(_source),index:'8f65ead0-2478-11ed-bf05-9f1feb2d4394',interval:auto,query:(language:lucene,query:'%22Connection%20reset%20by%20peer%22'),sort:!('@timestamp',desc))

Source: https://stackoverflow.com/questions/22697584/nginx-uwsgi-104-connection-reset-by-peer-while-reading-response-header-from-u