### PR TITLE
Upgrade Black to version 22.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ backcall==0.2.0
     # via ipython
 bandit==1.7.0
     # via -r requirements-dev.in
-black==20.8b1
+black==22.3
     # via -r requirements-dev.in
 certifi==2020.12.5
     # via
@@ -117,7 +117,7 @@ packaging==20.9
     #   safety
 parso==0.8.2
     # via jedi
-pathspec==0.8.1
+pathspec==0.9.0
     # via black
 pbr==5.5.1
     # via stevedore
@@ -211,7 +211,7 @@ traitlets==5.0.5
     #   matplotlib-inline
 typed-ast==1.4.2
     # via black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements.txt
     #   asgiref


### PR DESCRIPTION
Build have been failing for some time: https://dev.azure.com/City-of-Helsinki/hauki/_build/results?buildId=49796&view=logs&j=792982d5-3bb1-5d82-222e-228148b73448&t=54736b9a-3f29-59ec-e3cf-2bd50b89994e

Looks like upgrading Black did the trick. Found help from here https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click

Also the `pathspec` and `typing-extensions` needed to be upgraded.