### PR TITLE
Sort rules by created date when generating date_periods_as_text

### DIFF
--- a/hours/models.py
+++ b/hours/models.py
@@ -851,7 +851,8 @@ class TimeSpanGroup(SoftDeletableModel, models.Model):
 
     def as_text(self) -> str:
         rule_strings = []
-        for rule in self.rules.all():
+        rules = sorted(self.rules.all(), key=attrgetter("created"))
+        for rule in rules:
             if rule.is_removed:
                 continue
             rule_strings.append(" - " + rule.as_text())


### PR DESCRIPTION
# Problem
We faced an issue where ordering of the rules were different in the CI than in local causing unit tests fail.

# Solution
We decided that we could order the rules by created to make this ordering in this particular case more robust. Looks like the initial expectation was that the rules should be ordered in the order they are created.