### PR TITLE
Sort time span groups by rules in date periods as text

### DIFF
--- a/hours/models.py
+++ b/hours/models.py
@@ -680,11 +680,16 @@ class DatePeriod(SoftDeletableModel, TimeStampedModel):
 
     def as_text(self, after_start_date=datetime.date.min) -> str:
         group_strings = []
-        for time_span_group in self.time_span_groups.all():
-            if time_span_group.is_removed:
-                continue
-            if not time_span_group.time_spans.count():
-                continue
+        time_span_groups = sorted(
+            [
+                time_span_group
+                for time_span_group in self.time_span_groups.all()
+                if not time_span_group.is_removed and time_span_group.time_spans.count()
+            ],
+            key=lambda item: item.rules.all().count() != 0,
+        )
+
+        for time_span_group in time_span_groups:
             group_strings.append(time_span_group.as_text())
 
         if not group_strings and self.resource_state != State.UNDEFINED:


### PR DESCRIPTION
Sort time span groups with no rules as the first ones so it is easier for the citizens to understand which opening hours stand all  the time.

Now:

```
========================================\n
Aikajakso: 7. marraskuuta 2022 - \n
Aukioloajat:\n\n
 Maanantai-Torstai 8.00-16.00 Ajanvarauksella\n\n
 Voimassa kun kaikki seuraavat pätevät:\n
 - Jokaisen vuoden jokainen parillinen viikko\n\n
 ---------------------------------------\n\n
 Maanantai-Torstai 9.00-15.00 Itsepalvelu\n\n
 Voimassa kun kaikki seuraavat pätevät:\n
 - Jokaisen vuoden jokainen pariton viikko\n\n
 ---------------------------------------\n\n
 Perjantai 11.00-12.00 Auki\n
 Lauantai-Sunnuntai - Suljettu\n\n
========================================\n
```

Later:

```
========================================\n
Aikajakso: 7. marraskuuta 2022 - \n
Aukioloajat:\n\n
 Perjantai 11.00-12.00 Auki\n
 Lauantai-Sunnuntai - Suljettu\n\n
 ---------------------------------------\n\n
 Maanantai-Torstai 8.00-16.00 Ajanvarauksella\n\n
 Voimassa kun kaikki seuraavat pätevät:\n
 - Jokaisen vuoden jokainen parillinen viikko\n\n
 ---------------------------------------\n\n
 Maanantai-Torstai 9.00-15.00 Itsepalvelu\n\n
 Voimassa kun kaikki seuraavat pätevät:\n
 - Jokaisen vuoden jokainen pariton viikko\n\n
========================================\n
```