### PR TITLE
Allow login for same user from multiple systems

### DIFF
--- a/hours/authentication.py
+++ b/hours/authentication.py
@@ -190,8 +190,8 @@ class HaukiSignedAuthentication(BaseAuthentication):
             try:
                 user_origin = user.origins.get(data_source=data_source)
             except UserOrigin.DoesNotExist:
-                raise exceptions.AuthenticationFailed(
-                    _("User not from the same data source")
+                user_origin = UserOrigin.objects.create(
+                    user=user, data_source=data_source
                 )
         except User.DoesNotExist:
             user = User()
@@ -213,15 +213,12 @@ class HaukiSignedAuthentication(BaseAuthentication):
             try:
                 organization = Organization.objects.get(id=params["hsa_organization"])
 
-                # Allow joining users only to organizations that are from
-                # the same data source
-                if data_source == organization.data_source:
-                    users_organizations = user.organization_memberships.all()
+                users_organizations = user.organization_memberships.all()
 
-                    if organization not in users_organizations:
-                        user.organization_memberships.add(organization)
+                if organization not in users_organizations:
+                    user.organization_memberships.add(organization)
 
-                    hsa_auth_data.organization = organization
+                hsa_auth_data.organization = organization
             except Organization.DoesNotExist:
                 # TODO: Should we raise exception here
                 pass

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-10 08:06+0200\n"
+"POT-Creation-Date: 2022-12-21 11:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,7 +50,7 @@ msgstr ""
 msgid "End date"
 msgstr ""
 
-#: hours/admin.py:158 hours/models.py:641 hours/models.py:906
+#: hours/admin.py:158 hours/models.py:641 hours/models.py:911
 msgid "Resource state"
 msgstr ""
 
@@ -91,10 +91,6 @@ msgstr ""
 
 #: hours/authentication.py:183
 msgid "Signature has been invalidated"
-msgstr ""
-
-#: hours/authentication.py:194
-msgid "User not from the same data source"
 msgstr ""
 
 #: hours/authentication.py:205
@@ -450,12 +446,12 @@ msgid "Odd"
 msgstr ""
 
 #: hours/models.py:254 hours/models.py:281 hours/models.py:630
-#: hours/models.py:882 hours/models.py:1012
+#: hours/models.py:887 hours/models.py:1017
 msgid "Name"
 msgstr ""
 
 #: hours/models.py:255 hours/models.py:283 hours/models.py:632
-#: hours/models.py:884 hours/models.py:1014
+#: hours/models.py:889 hours/models.py:1019
 msgid "Description"
 msgstr ""
 
@@ -507,7 +503,7 @@ msgstr ""
 msgid "{separator}{date_periods}{separator}"
 msgstr ""
 
-#: hours/models.py:608 hours/models.py:810 users/models.py:38
+#: hours/models.py:608 hours/models.py:815 users/models.py:38
 msgid "Origin ID"
 msgstr ""
 
@@ -531,7 +527,7 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: hours/models.py:693
+#: hours/models.py:698
 msgid ""
 "\n"
 "\n"
@@ -539,11 +535,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: hours/models.py:703
+#: hours/models.py:708
 msgid "Not specified"
 msgstr ""
 
-#: hours/models.py:716
+#: hours/models.py:721
 #, python-brace-format
 msgid ""
 "{name}{description}Date period: {dates}\n"
@@ -552,210 +548,210 @@ msgid ""
 "{time_span_groups}\n"
 msgstr ""
 
-#: hours/models.py:814
+#: hours/models.py:819
 msgid "Period origin"
 msgstr ""
 
-#: hours/models.py:815
+#: hours/models.py:820
 msgid "Period origins"
 msgstr ""
 
-#: hours/models.py:870
+#: hours/models.py:875
 msgid ""
 "\n"
 "\n"
 " In effect when every one of these match:\n"
 msgstr ""
 
-#: hours/models.py:886
+#: hours/models.py:891
 msgid "Start time"
 msgstr ""
 
-#: hours/models.py:889
+#: hours/models.py:894
 msgid "End time"
 msgstr ""
 
-#: hours/models.py:892
+#: hours/models.py:897
 msgid "Is end time on the next day"
 msgstr ""
 
-#: hours/models.py:894
+#: hours/models.py:899
 msgid "24 hours"
 msgstr ""
 
-#: hours/models.py:898
+#: hours/models.py:903
 msgid "Weekday"
 msgstr ""
 
-#: hours/models.py:912
+#: hours/models.py:917
 msgid "Time span"
 msgstr ""
 
-#: hours/models.py:913
+#: hours/models.py:918
 msgid "Time spans"
 msgstr ""
 
-#: hours/models.py:952
+#: hours/models.py:957
 msgctxt "timespan_as_text"
 msgid "Every day"
 msgstr ""
 
-#: hours/models.py:979
+#: hours/models.py:984
 msgctxt "timespan_as_text"
 msgid "The whole day"
 msgstr ""
 
-#: hours/models.py:981
+#: hours/models.py:986
 #, python-brace-format
 msgctxt "timespan_as_text"
 msgid "{start_time}-{end_time}"
 msgstr ""
 
-#: hours/models.py:998
+#: hours/models.py:1003
 #, python-brace-format
 msgctxt "timespan_as_text"
 msgid "{weekdays} {times} {state}{description}"
 msgstr ""
 
-#: hours/models.py:1017
+#: hours/models.py:1022
 msgid "Context"
 msgstr ""
 
-#: hours/models.py:1022
+#: hours/models.py:1027
 msgid "Subject"
 msgstr ""
 
-#: hours/models.py:1025
+#: hours/models.py:1030
 msgid "Start"
 msgstr ""
 
-#: hours/models.py:1027
+#: hours/models.py:1032
 msgid "Frequency (ordinal)"
 msgstr ""
 
-#: hours/models.py:1031
+#: hours/models.py:1036
 msgid "Frequency (modifier)"
 msgstr ""
 
-#: hours/models.py:1038
+#: hours/models.py:1043
 msgid "Rule"
 msgstr ""
 
-#: hours/models.py:1039
+#: hours/models.py:1044
 msgid "Rules"
 msgstr ""
 
-#: hours/models.py:1069
+#: hours/models.py:1074
 msgctxt "rule_as_text_context"
 msgid "the period"
 msgstr ""
 
-#: hours/models.py:1071
+#: hours/models.py:1076
 #, python-brace-format
 msgctxt "rule_as_text_context"
 msgid "every {context}"
 msgstr ""
 
-#: hours/models.py:1077
+#: hours/models.py:1082
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "{nth} {subject} in {context}"
 msgstr ""
 
-#: hours/models.py:1086
+#: hours/models.py:1091
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "starting from the {nth} {last} {subject}"
 msgstr ""
 
-#: hours/models.py:1089
+#: hours/models.py:1094
 msgctxt "starting_from_the_last"
 msgid "last"
 msgstr ""
 
-#: hours/models.py:1099
+#: hours/models.py:1104
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "Every {nth} {subject} in {context} {starting_from_text}"
 msgstr ""
 
-#: hours/models.py:1110
+#: hours/models.py:1115
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "On {modifier} {subject}s in {context}"
 msgstr ""
 
-#: hours/models.py:1131
+#: hours/models.py:1136
 msgid ""
 "We cannot start counting from period start in an infinite period. Please "
 "select shorter context for your rule."
 msgstr ""
 
-#: hours/models.py:1136
+#: hours/models.py:1141
 msgid "Subject must be a shorter timespan than context."
 msgstr ""
 
-#: hours/models.py:1140
+#: hours/models.py:1145
 msgid ""
 "You cannot add a rule with both even/odd and another frequency at the same "
 "time."
 msgstr ""
 
-#: hours/models.py:1149
+#: hours/models.py:1154
 msgid ""
 "Rule can only start from zero if starting from zeroth ISO week of the year. "
 "All other rules start counting from 1. Use negative numbers to count from "
 "the end of the context."
 msgstr ""
 
-#: hours/models.py:1157
+#: hours/models.py:1162
 msgid ""
 "Even/odd subjects are not counted starting from a specific time. If you wish "
 "to have an alternating rule starting from a specific time, please use "
 "frequency_ordinal=2 with start=1 or start=2."
 msgstr ""
 
-#: hours/models.py:1424
+#: hours/models.py:1429
 msgid "Signature"
 msgstr ""
 
-#: hours/models.py:1425
+#: hours/models.py:1430
 msgid "Signature created at"
 msgstr ""
 
-#: hours/models.py:1426
+#: hours/models.py:1431
 msgid "Signature valid until"
 msgstr ""
 
-#: hours/models.py:1428
+#: hours/models.py:1433
 msgid "Invalidated time"
 msgstr ""
 
-#: hours/models.py:1432
+#: hours/models.py:1437
 msgid "Signed auth entry"
 msgstr ""
 
-#: hours/models.py:1433
+#: hours/models.py:1438
 msgid "Signed auth entries"
 msgstr ""
 
-#: hours/models.py:1438
+#: hours/models.py:1443
 msgid "Signing key"
 msgstr ""
 
-#: hours/models.py:1439
+#: hours/models.py:1444
 msgid "Key valid after"
 msgstr ""
 
-#: hours/models.py:1441
+#: hours/models.py:1446
 msgid "Key valid until"
 msgstr ""
 
-#: hours/models.py:1445
+#: hours/models.py:1450
 msgid "Signed auth key"
 msgstr ""
 
-#: hours/models.py:1446
+#: hours/models.py:1451
 msgid "Signed auth keys"
 msgstr ""
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-10 08:06+0200\n"
+"POT-Creation-Date: 2022-12-21 11:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,7 +49,7 @@ msgstr "Alkupäivämäärä"
 msgid "End date"
 msgstr "Loppupäivämäärä"
 
-#: hours/admin.py:158 hours/models.py:641 hours/models.py:906
+#: hours/admin.py:158 hours/models.py:641 hours/models.py:911
 msgid "Resource state"
 msgstr "Resurssin tila"
 
@@ -90,10 +90,6 @@ msgstr ""
 
 #: hours/authentication.py:183
 msgid "Signature has been invalidated"
-msgstr ""
-
-#: hours/authentication.py:194
-msgid "User not from the same data source"
 msgstr ""
 
 #: hours/authentication.py:205
@@ -416,12 +412,12 @@ msgid "Odd"
 msgstr "Pariton"
 
 #: hours/models.py:254 hours/models.py:281 hours/models.py:630
-#: hours/models.py:882 hours/models.py:1012
+#: hours/models.py:887 hours/models.py:1017
 msgid "Name"
 msgstr "Nimi"
 
 #: hours/models.py:255 hours/models.py:283 hours/models.py:632
-#: hours/models.py:884 hours/models.py:1014
+#: hours/models.py:889 hours/models.py:1019
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -473,7 +469,7 @@ msgstr ""
 msgid "{separator}{date_periods}{separator}"
 msgstr ""
 
-#: hours/models.py:608 hours/models.py:810 users/models.py:38
+#: hours/models.py:608 hours/models.py:815 users/models.py:38
 msgid "Origin ID"
 msgstr "Tunniste lähdejärjestelmässä"
 
@@ -497,7 +493,7 @@ msgstr "Jakso"
 msgid "Periods"
 msgstr "Jaksot"
 
-#: hours/models.py:693
+#: hours/models.py:698
 msgid ""
 "\n"
 "\n"
@@ -505,11 +501,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: hours/models.py:703
+#: hours/models.py:708
 msgid "Not specified"
 msgstr "Ei määritelty"
 
-#: hours/models.py:716
+#: hours/models.py:721
 #, python-brace-format
 msgid ""
 "{name}{description}Date period: {dates}\n"
@@ -522,15 +518,15 @@ msgstr ""
 "\n"
 "{time_span_groups}\n"
 
-#: hours/models.py:814
+#: hours/models.py:819
 msgid "Period origin"
 msgstr "Jakson lähde"
 
-#: hours/models.py:815
+#: hours/models.py:820
 msgid "Period origins"
 msgstr "Jakson lähteet"
 
-#: hours/models.py:870
+#: hours/models.py:875
 msgid ""
 "\n"
 "\n"
@@ -540,51 +536,51 @@ msgstr ""
 "\n"
 " Voimassa kun kaikki seuraavat pätevät:\n"
 
-#: hours/models.py:886
+#: hours/models.py:891
 msgid "Start time"
 msgstr "Alkuaika"
 
-#: hours/models.py:889
+#: hours/models.py:894
 msgid "End time"
 msgstr "Loppuaika"
 
-#: hours/models.py:892
+#: hours/models.py:897
 msgid "Is end time on the next day"
 msgstr ""
 
-#: hours/models.py:894
+#: hours/models.py:899
 msgid "24 hours"
 msgstr "24 tuntia"
 
-#: hours/models.py:898
+#: hours/models.py:903
 msgid "Weekday"
 msgstr "Viikonpäivä"
 
-#: hours/models.py:912
+#: hours/models.py:917
 msgid "Time span"
 msgstr "Aikaväli"
 
-#: hours/models.py:913
+#: hours/models.py:918
 msgid "Time spans"
 msgstr "Aikavälit"
 
-#: hours/models.py:952
+#: hours/models.py:957
 msgctxt "timespan_as_text"
 msgid "Every day"
 msgstr "Joka päivä"
 
-#: hours/models.py:979
+#: hours/models.py:984
 msgctxt "timespan_as_text"
 msgid "The whole day"
 msgstr "Koko päivän"
 
-#: hours/models.py:981
+#: hours/models.py:986
 #, python-brace-format
 msgctxt "timespan_as_text"
 msgid "{start_time}-{end_time}"
 msgstr "{start_time}-{end_time}"
 
-#: hours/models.py:998
+#: hours/models.py:1003
 #, fuzzy, python-brace-format
 #| msgctxt "timespan_as_text"
 #| msgid "{weekdays} {times} {state}"
@@ -592,145 +588,145 @@ msgctxt "timespan_as_text"
 msgid "{weekdays} {times} {state}{description}"
 msgstr "{weekdays} {times} {state}"
 
-#: hours/models.py:1017
+#: hours/models.py:1022
 msgid "Context"
 msgstr "Konteksti"
 
-#: hours/models.py:1022
+#: hours/models.py:1027
 msgid "Subject"
 msgstr "Kohde"
 
-#: hours/models.py:1025
+#: hours/models.py:1030
 msgid "Start"
 msgstr "Alku"
 
-#: hours/models.py:1027
+#: hours/models.py:1032
 msgid "Frequency (ordinal)"
 msgstr "Toistuvuus (järjestysnumero)"
 
-#: hours/models.py:1031
+#: hours/models.py:1036
 msgid "Frequency (modifier)"
 msgstr "Toistuvuus (määre)"
 
-#: hours/models.py:1038
+#: hours/models.py:1043
 msgid "Rule"
 msgstr "Sääntö"
 
-#: hours/models.py:1039
+#: hours/models.py:1044
 msgid "Rules"
 msgstr "Säännöt"
 
-#: hours/models.py:1069
+#: hours/models.py:1074
 msgctxt "rule_as_text_context"
 msgid "the period"
 msgstr "Jakson"
 
-#: hours/models.py:1071
+#: hours/models.py:1076
 #, python-brace-format
 msgctxt "rule_as_text_context"
 msgid "every {context}"
 msgstr "Jokaisen {context}"
 
-#: hours/models.py:1077
+#: hours/models.py:1082
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "{nth} {subject} in {context}"
 msgstr "{context} {nth} {subject}"
 
-#: hours/models.py:1086
+#: hours/models.py:1091
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "starting from the {nth} {last} {subject}"
 msgstr "alkaen {nth} {last} {subject}"
 
-#: hours/models.py:1089
+#: hours/models.py:1094
 msgctxt "starting_from_the_last"
 msgid "last"
 msgstr "viimeisestä"
 
-#: hours/models.py:1099
+#: hours/models.py:1104
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "Every {nth} {subject} in {context} {starting_from_text}"
 msgstr "{context} joka {nth} {subject} {starting_from_text}"
 
-#: hours/models.py:1110
+#: hours/models.py:1115
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "On {modifier} {subject}s in {context}"
 msgstr "{context} jokainen {modifier} {subject}"
 
-#: hours/models.py:1131
+#: hours/models.py:1136
 msgid ""
 "We cannot start counting from period start in an infinite period. Please "
 "select shorter context for your rule."
 msgstr ""
 
-#: hours/models.py:1136
+#: hours/models.py:1141
 msgid "Subject must be a shorter timespan than context."
 msgstr ""
 
-#: hours/models.py:1140
+#: hours/models.py:1145
 msgid ""
 "You cannot add a rule with both even/odd and another frequency at the same "
 "time."
 msgstr ""
 
-#: hours/models.py:1149
+#: hours/models.py:1154
 msgid ""
 "Rule can only start from zero if starting from zeroth ISO week of the year. "
 "All other rules start counting from 1. Use negative numbers to count from "
 "the end of the context."
 msgstr ""
 
-#: hours/models.py:1157
+#: hours/models.py:1162
 msgid ""
 "Even/odd subjects are not counted starting from a specific time. If you wish "
 "to have an alternating rule starting from a specific time, please use "
 "frequency_ordinal=2 with start=1 or start=2."
 msgstr ""
 
-#: hours/models.py:1424
+#: hours/models.py:1429
 msgid "Signature"
 msgstr "Allekirjoitus"
 
-#: hours/models.py:1425
+#: hours/models.py:1430
 msgid "Signature created at"
 msgstr "Allekirjoituksen luontiaika"
 
-#: hours/models.py:1426
+#: hours/models.py:1431
 msgid "Signature valid until"
 msgstr "Allekirjoituksen vanhenemisaika"
 
-#: hours/models.py:1428
+#: hours/models.py:1433
 msgid "Invalidated time"
 msgstr "Mitätöintiaika"
 
-#: hours/models.py:1432
+#: hours/models.py:1437
 msgid "Signed auth entry"
 msgstr ""
 
-#: hours/models.py:1433
+#: hours/models.py:1438
 msgid "Signed auth entries"
 msgstr ""
 
-#: hours/models.py:1438
+#: hours/models.py:1443
 msgid "Signing key"
 msgstr "Allekirjoitusavain"
 
-#: hours/models.py:1439
+#: hours/models.py:1444
 msgid "Key valid after"
 msgstr "Avaimen voimassaoloaika alkaa"
 
-#: hours/models.py:1441
+#: hours/models.py:1446
 msgid "Key valid until"
 msgstr "Avaimen voimassaoloaika loppuu"
 
-#: hours/models.py:1445
+#: hours/models.py:1450
 msgid "Signed auth key"
 msgstr ""
 
-#: hours/models.py:1446
+#: hours/models.py:1451
 msgid "Signed auth keys"
 msgstr ""
 
@@ -830,3 +826,8 @@ msgstr "Käyttäjän lähde"
 #: users/models.py:43
 msgid "User origins"
 msgstr "Käyttäjän lähteet"
+
+#, fuzzy
+#~| msgid "Resource origin"
+#~ msgid "Resource not found"
+#~ msgstr "Resurssin lähde"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-10 08:06+0200\n"
+"POT-Creation-Date: 2022-12-21 11:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,7 +49,7 @@ msgstr ""
 msgid "End date"
 msgstr ""
 
-#: hours/admin.py:158 hours/models.py:641 hours/models.py:906
+#: hours/admin.py:158 hours/models.py:641 hours/models.py:911
 msgid "Resource state"
 msgstr ""
 
@@ -90,10 +90,6 @@ msgstr ""
 
 #: hours/authentication.py:183
 msgid "Signature has been invalidated"
-msgstr ""
-
-#: hours/authentication.py:194
-msgid "User not from the same data source"
 msgstr ""
 
 #: hours/authentication.py:205
@@ -416,12 +412,12 @@ msgid "Odd"
 msgstr "Udd"
 
 #: hours/models.py:254 hours/models.py:281 hours/models.py:630
-#: hours/models.py:882 hours/models.py:1012
+#: hours/models.py:887 hours/models.py:1017
 msgid "Name"
 msgstr ""
 
 #: hours/models.py:255 hours/models.py:283 hours/models.py:632
-#: hours/models.py:884 hours/models.py:1014
+#: hours/models.py:889 hours/models.py:1019
 msgid "Description"
 msgstr ""
 
@@ -473,7 +469,7 @@ msgstr ""
 msgid "{separator}{date_periods}{separator}"
 msgstr ""
 
-#: hours/models.py:608 hours/models.py:810 users/models.py:38
+#: hours/models.py:608 hours/models.py:815 users/models.py:38
 msgid "Origin ID"
 msgstr ""
 
@@ -497,7 +493,7 @@ msgstr ""
 msgid "Periods"
 msgstr ""
 
-#: hours/models.py:693
+#: hours/models.py:698
 msgid ""
 "\n"
 "\n"
@@ -505,11 +501,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: hours/models.py:703
+#: hours/models.py:708
 msgid "Not specified"
 msgstr "Ej fastställt"
 
-#: hours/models.py:716
+#: hours/models.py:721
 #, python-brace-format
 msgid ""
 "{name}{description}Date period: {dates}\n"
@@ -522,15 +518,15 @@ msgstr ""
 "\n"
 "{time_span_groups}\n"
 
-#: hours/models.py:814
+#: hours/models.py:819
 msgid "Period origin"
 msgstr ""
 
-#: hours/models.py:815
+#: hours/models.py:820
 msgid "Period origins"
 msgstr ""
 
-#: hours/models.py:870
+#: hours/models.py:875
 msgid ""
 "\n"
 "\n"
@@ -540,195 +536,195 @@ msgstr ""
 "\n"
 "Giltig när alla följanär gäller:\n"
 
-#: hours/models.py:886
+#: hours/models.py:891
 msgid "Start time"
 msgstr ""
 
-#: hours/models.py:889
+#: hours/models.py:894
 msgid "End time"
 msgstr ""
 
-#: hours/models.py:892
+#: hours/models.py:897
 msgid "Is end time on the next day"
 msgstr ""
 
-#: hours/models.py:894
+#: hours/models.py:899
 msgid "24 hours"
 msgstr "24 timmar"
 
-#: hours/models.py:898
+#: hours/models.py:903
 msgid "Weekday"
 msgstr "Veckodag"
 
-#: hours/models.py:912
+#: hours/models.py:917
 msgid "Time span"
 msgstr ""
 
-#: hours/models.py:913
+#: hours/models.py:918
 msgid "Time spans"
 msgstr ""
 
-#: hours/models.py:952
+#: hours/models.py:957
 msgctxt "timespan_as_text"
 msgid "Every day"
 msgstr "Varje dag"
 
-#: hours/models.py:979
+#: hours/models.py:984
 msgctxt "timespan_as_text"
 msgid "The whole day"
 msgstr "Hela dagen"
 
-#: hours/models.py:981
+#: hours/models.py:986
 #, python-brace-format
 msgctxt "timespan_as_text"
 msgid "{start_time}-{end_time}"
 msgstr ""
 
-#: hours/models.py:998
+#: hours/models.py:1003
 #, python-brace-format
 msgctxt "timespan_as_text"
 msgid "{weekdays} {times} {state}{description}"
 msgstr ""
 
-#: hours/models.py:1017
+#: hours/models.py:1022
 msgid "Context"
 msgstr ""
 
-#: hours/models.py:1022
+#: hours/models.py:1027
 msgid "Subject"
 msgstr ""
 
-#: hours/models.py:1025
+#: hours/models.py:1030
 msgid "Start"
 msgstr "Början"
 
-#: hours/models.py:1027
+#: hours/models.py:1032
 msgid "Frequency (ordinal)"
 msgstr "Upprepning (sekvensnummer)"
 
-#: hours/models.py:1031
+#: hours/models.py:1036
 msgid "Frequency (modifier)"
 msgstr "Upprepning (kval)"
 
-#: hours/models.py:1038
+#: hours/models.py:1043
 msgid "Rule"
 msgstr "Reger"
 
-#: hours/models.py:1039
+#: hours/models.py:1044
 msgid "Rules"
 msgstr "Regler"
 
-#: hours/models.py:1069
+#: hours/models.py:1074
 msgctxt "rule_as_text_context"
 msgid "the period"
 msgstr "Av period"
 
-#: hours/models.py:1071
+#: hours/models.py:1076
 #, python-brace-format
 msgctxt "rule_as_text_context"
 msgid "every {context}"
 msgstr "Varje {context}"
 
-#: hours/models.py:1077
+#: hours/models.py:1082
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "{nth} {subject} in {context}"
 msgstr "{context} {nth} {subject}"
 
-#: hours/models.py:1086
+#: hours/models.py:1091
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "starting from the {nth} {last} {subject}"
 msgstr "från {nth} {last} {subject}"
 
-#: hours/models.py:1089
+#: hours/models.py:1094
 msgctxt "starting_from_the_last"
 msgid "last"
 msgstr "från den sista"
 
-#: hours/models.py:1099
+#: hours/models.py:1104
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "Every {nth} {subject} in {context} {starting_from_text}"
 msgstr "{context} varje {nth} {subject} {starting_from_text}"
 
-#: hours/models.py:1110
+#: hours/models.py:1115
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "On {modifier} {subject}s in {context}"
 msgstr "{context} varje {modifier} {subject}"
 
-#: hours/models.py:1131
+#: hours/models.py:1136
 msgid ""
 "We cannot start counting from period start in an infinite period. Please "
 "select shorter context for your rule."
 msgstr ""
 
-#: hours/models.py:1136
+#: hours/models.py:1141
 msgid "Subject must be a shorter timespan than context."
 msgstr ""
 
-#: hours/models.py:1140
+#: hours/models.py:1145
 msgid ""
 "You cannot add a rule with both even/odd and another frequency at the same "
 "time."
 msgstr ""
 
-#: hours/models.py:1149
+#: hours/models.py:1154
 msgid ""
 "Rule can only start from zero if starting from zeroth ISO week of the year. "
 "All other rules start counting from 1. Use negative numbers to count from "
 "the end of the context."
 msgstr ""
 
-#: hours/models.py:1157
+#: hours/models.py:1162
 msgid ""
 "Even/odd subjects are not counted starting from a specific time. If you wish "
 "to have an alternating rule starting from a specific time, please use "
 "frequency_ordinal=2 with start=1 or start=2."
 msgstr ""
 
-#: hours/models.py:1424
+#: hours/models.py:1429
 msgid "Signature"
 msgstr ""
 
-#: hours/models.py:1425
+#: hours/models.py:1430
 msgid "Signature created at"
 msgstr ""
 
-#: hours/models.py:1426
+#: hours/models.py:1431
 msgid "Signature valid until"
 msgstr ""
 
-#: hours/models.py:1428
+#: hours/models.py:1433
 msgid "Invalidated time"
 msgstr ""
 
-#: hours/models.py:1432
+#: hours/models.py:1437
 msgid "Signed auth entry"
 msgstr ""
 
-#: hours/models.py:1433
+#: hours/models.py:1438
 msgid "Signed auth entries"
 msgstr ""
 
-#: hours/models.py:1438
+#: hours/models.py:1443
 msgid "Signing key"
 msgstr ""
 
-#: hours/models.py:1439
+#: hours/models.py:1444
 msgid "Key valid after"
 msgstr ""
 
-#: hours/models.py:1441
+#: hours/models.py:1446
 msgid "Key valid until"
 msgstr ""
 
-#: hours/models.py:1445
+#: hours/models.py:1450
 msgid "Signed auth key"
 msgstr ""
 
-#: hours/models.py:1446
+#: hours/models.py:1451
 msgid "Signed auth keys"
 msgstr ""
 


### PR DESCRIPTION
### Context & opportunity
- At the moment same user cannot use Aukiolosovellus from both TPR or Varaamo since data source restrictions
- Varaamo is using the same org structure as TPR causing the user not being added to the org causing copying opening hours somewhere in the future to fail

### Intervention
- Remove check for data_source from the user and add the provided data_source to the user instead
- Remove check of data_source from the organization and add the user to the given organization instead

### Outcome
- User can log in from multiple systems e.g Varaamo and TPR.
