### PR TITLE
Mark existing connection resources as non-public when not found from TPR during import

### DIFF
--- a/hours/importer/tprek.py
+++ b/hours/importer/tprek.py
@@ -211,16 +211,15 @@ class TPRekImporter(Importer):
         return not obj.is_public
 
     def mark_deleted(self, obj: SoftDeletableModel) -> bool:
-        # Only TPREK units will be marked non-public instead of deleted.
+        # TPREK units and connections will be marked non-public instead of deleted.
         # They might still lurk in TPREK and be needed non-publicly.
-        if type(obj) == Resource and obj.resource_type == ResourceType.UNIT:
+        if type(obj) == Resource:
             return self.mark_non_public(obj)
-        # TPREK does not have non-public connections. Connections and opening
-        # hours will be deleted.
+        # Opening hours will be deleted.
         return super().mark_deleted(obj)
 
     def check_deleted(self, obj: SoftDeletableModel) -> bool:
-        if type(obj) == Resource and obj.resource_type == ResourceType.UNIT:
+        if type(obj) == Resource:
             return self.check_non_public(obj)
         return super().check_deleted(obj)
 


### PR DESCRIPTION
# Context & problem

At the moment when a unit is marked as non-public in TPR the `https://www.hel.fi/palvelukarttaws/rest/v4/unit/`endpoint won't return that unit anymore. When the importer is run the next morning it will sync the resources with the result from that endpoint and since the unit is not there it will mark that as non-public. This is fine and works as expected.

The issue is that the unit might have some [connections](https://github.com/City-of-Helsinki/hauki/blob/master/hours/enums.py#L57) and when the parent is not found the connections will be deleted and the opening hours lost. This is not desirable.

# Proposed solution

Use the same kind of handling for all the resources whether those are units or connections. This way we the user won't lose the data whenever she decides to hide the unit for some reason or another.

