### PR TITLE
Set connectionmode to hauki when fetching units from TPR

### DIFF
--- a/hours/importer/tprek.py
+++ b/hours/importer/tprek.py
@@ -1225,7 +1225,7 @@ class TPRekImporter(Importer):
         api_params = {
             "official": "yes",
         }
-        if object_type == "connection":
+        if object_type in ["unit", "connection"]:
             api_params["connectionmode"] = "hauki"
 
         if self.options.get("single", None):


### PR DESCRIPTION
# Context & problem
At the moment when units are fetched from TPR it contains instances from origins that are not supposed to flow to Hauki. PTVOUT is one of these.

# Proposed solution
Add `connectionmode` `hauki` to `https://www.hel.fi/palvelukarttaws/rest/v4/unit/` request. It is also used when fetching connections via `https://www.hel.fi/palvelukarttaws/rest/v4/connection/`. This way TPR controls which untis & connections should be created as new resources in Hauki or which resources should be hidden.