### PR TITLE
Upgrade requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,10 +10,6 @@ asgiref==3.6.0
     #   django
 asttokens==2.2.1
     # via stack-data
-attrs==22.2.0
-    # via
-    #   -c requirements.txt
-    #   pytest
 backcall==0.2.0
     # via ipython
 bandit==1.7.5
@@ -37,13 +33,13 @@ click==8.1.3
     #   black
     #   pip-tools
     #   safety
-coverage[toml]==7.2.2
+coverage[toml]==7.2.5
     # via pytest-cov
 decorator==5.1.1
     # via ipython
 distlib==0.3.6
     # via virtualenv
-django==3.2.18
+django==3.2.19
     # via
     #   -c requirements.txt
     #   django-extensions
@@ -61,11 +57,11 @@ factory-boy==3.2.1
     # via
     #   -r requirements-dev.in
     #   pytest-factoryboy
-faker==18.3.1
+faker==18.6.2
     # via
     #   -r requirements-dev.in
     #   factory-boy
-filelock==3.10.7
+filelock==3.12.0
     # via virtualenv
 flake8==6.0.0
     # via -r requirements-dev.in
@@ -75,7 +71,7 @@ gitdb==4.0.10
     # via gitpython
 gitpython==3.1.31
     # via bandit
-identify==2.5.22
+identify==2.5.24
     # via pre-commit
 idna==3.4
     # via
@@ -87,7 +83,7 @@ inflection==0.5.1
     #   pytest-factoryboy
 iniconfig==2.0.0
     # via pytest
-ipython==8.11.0
+ipython==8.13.2
     # via -r requirements-dev.in
 isort==5.12.0
     # via -r requirements-dev.in
@@ -105,7 +101,7 @@ mypy-extensions==1.0.0
     # via black
 nodeenv==1.7.0
     # via pre-commit
-packaging==23.0
+packaging==23.1
     # via
     #   -c requirements.txt
     #   black
@@ -123,16 +119,16 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements-dev.in
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   -c requirements.txt
     #   black
     #   virtualenv
 pluggy==1.0.0
     # via pytest
-pre-commit==3.2.1
+pre-commit==3.3.1
     # via -r requirements-dev.in
 prompt-toolkit==3.0.38
     # via ipython
@@ -144,13 +140,13 @@ pycodestyle==2.10.0
     # via flake8
 pyflakes==3.0.1
     # via flake8
-pygments==2.14.0
+pygments==2.15.1
     # via
     #   ipython
     #   rich
 pyproject-hooks==1.0.0
     # via build
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -176,16 +172,16 @@ pyyaml==6.0
     #   -c requirements.txt
     #   bandit
     #   pre-commit
-requests==2.28.2
+requests==2.30.0
     # via
     #   -c requirements.txt
     #   requests-mock
     #   safety
 requests-mock==1.10.0
     # via -r requirements-dev.in
-rich==13.3.3
+rich==13.3.5
     # via bandit
-ruamel-yaml==0.17.21
+ruamel-yaml==0.17.22
     # via safety
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -199,7 +195,7 @@ six==1.16.0
     #   requests-mock
 smmap==5.0.0
     # via gitdb
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -c requirements.txt
     #   django
@@ -224,12 +220,13 @@ typing-extensions==4.5.0
     # via
     #   -c requirements.txt
     #   black
+    #   ipython
     #   pytest-factoryboy
 urllib3==1.26.15
     # via
     #   -c requirements.txt
     #   requests
-virtualenv==20.21.0
+virtualenv==20.23.0
     # via pre-commit
 wcwidth==0.2.6
     # via prompt-toolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.6.0
     # via django
-attrs==22.2.0
+attrs==23.1.0
     # via
     #   cattrs
     #   jsonschema
@@ -24,11 +24,9 @@ certifi==2022.12.7
     #   sentry-sdk
 charset-normalizer==3.1.0
     # via requests
-convertdate==2.4.0
-    # via holidays
 deprecation==2.1.0
     # via django-helusers
-django==3.2.18
+django==3.2.19
     # via
     #   -r requirements.in
     #   django-cors-headers
@@ -38,6 +36,7 @@ django==3.2.18
     #   django-js-asset
     #   django-model-utils
     #   django-modeltranslation
+    #   django-orghierarchy
     #   djangorestframework
     #   drf-spectacular
 django-cors-headers==3.14.0
@@ -48,9 +47,9 @@ django-environ==0.10.0
     # via -r requirements.in
 django-extra-fields==3.0.2
     # via -r requirements.in
-django-filter==23.1
+django-filter==23.2
     # via -r requirements.in
-django-helusers==0.8.0
+django-helusers==0.8.1
     # via -r requirements.in
 django-js-asset==2.0.0
     # via django-mptt
@@ -60,7 +59,7 @@ django-modeltranslation==0.18.9
     # via -r requirements.in
 django-mptt==0.14.0
     # via django-orghierarchy
-django-orghierarchy==0.1.32
+django-orghierarchy==0.3.0
     # via -r requirements.in
 django-simple-history==3.3.0
     # via -r requirements.in
@@ -72,7 +71,7 @@ djangorestframework==3.14.0
     #   django-extra-fields
     #   django-orghierarchy
     #   drf-spectacular
-drf-spectacular==0.26.1
+drf-spectacular==0.26.2
     # via -r requirements.in
 drf-writable-nested==0.7.0
     # via -r requirements.in
@@ -82,9 +81,9 @@ elastic-apm==6.15.1
     # via -r requirements.in
 exceptiongroup==1.1.1
     # via cattrs
-hijri-converter==2.2.4
+hijri-converter==2.3.1
     # via holidays
-holidays==0.21.13
+holidays==0.24
     # via -r requirements.in
 idna==3.4
     # via requests
@@ -94,20 +93,16 @@ jsonschema==4.17.3
     # via drf-spectacular
 korean-lunar-calendar==0.3.1
     # via holidays
-packaging==23.0
+packaging==23.1
     # via deprecation
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via requests-cache
-psycopg2==2.9.5
+psycopg2==2.9.6
     # via -r requirements.in
-pyasn1==0.4.8
+pyasn1==0.5.0
     # via
     #   python-jose
     #   rsa
-pymeeus==0.5.12
-    # via
-    #   convertdate
-    #   holidays
 pyrsistent==0.19.3
     # via jsonschema
 python-dateutil==2.8.2
@@ -121,7 +116,7 @@ pytz==2023.3
     #   djangorestframework
 pyyaml==6.0
     # via drf-spectacular
-requests==2.28.2
+requests==2.30.0
     # via
     #   django-helusers
     #   django-orghierarchy
@@ -130,7 +125,7 @@ requests-cache==1.0.1
     # via -r requirements.in
 rsa==4.9
     # via python-jose
-sentry-sdk==1.18.0
+sentry-sdk==1.21.1
     # via -r requirements.in
 six==1.16.0
     # via
@@ -138,7 +133,7 @@ six==1.16.0
     #   ecdsa
     #   python-dateutil
     #   url-normalize
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
 swapper==1.3.0
     # via django-orghierarchy


### PR DESCRIPTION
Upgrade to latest minor/patch versions, Snyk only gets it half-done (e.g. upgrading Django patch version only in `requirements-dev.txt`, not `requirements.txt`), so might as well do it properly.