### PR TITLE
HAUKI-582: Add the option to specify which date periods to copy from a resource

### DIFF
--- a/hours/models.py
+++ b/hours/models.py
@@ -547,7 +547,19 @@ class Resource(SoftDeletableModel, TimeStampedModel):
 
         return acc
 
-    def copy_all_periods_to_resource(self, target_resource, replace=False):
+    def copy_periods_to_resource(
+        self,
+        target_resource: Resource,
+        date_period_ids: list = None,
+        replace: bool = False,
+    ):
+        """
+        Copies date periods from this resource to the target resource.
+
+        If date_period_ids is not specified, all date periods are copied.
+
+        If replace is True, the target resource's existing date periods are deleted.
+        """
         if (
             not target_resource
             or not isinstance(target_resource, Resource)
@@ -556,6 +568,7 @@ class Resource(SoftDeletableModel, TimeStampedModel):
             return
 
         existing_period_ids = []
+
         if replace:
             existing_period_ids = list(
                 target_resource.date_periods.all().values_list("id", flat=True)
@@ -570,7 +583,12 @@ class Resource(SoftDeletableModel, TimeStampedModel):
 
             return new_instance
 
-        for period in self.date_periods.all():
+        if date_period_ids:
+            date_periods = self.date_periods.filter(id__in=date_period_ids)
+        else:
+            date_periods = self.date_periods.all()
+
+        for period in date_periods:
             new_period = copy_instance(period, "resource", target_resource)
 
             for time_span_group in period.time_span_groups.all():

--- a/hours/tests/test_copy_date_periods.py
+++ b/hours/tests/test_copy_date_periods.py
@@ -13,6 +13,104 @@ from hours.tests.conftest import (
     TimeSpanGroupFactory,
 )
 
+DEFAULT_YEAR = 2020
+DEFAULT_START_OF_YEAR = datetime.date(year=DEFAULT_YEAR, month=1, day=1)
+DEFAULT_END_OF_YEAR = datetime.date(year=DEFAULT_YEAR, month=12, day=31)
+
+
+def start_of_month(month, year=DEFAULT_YEAR):
+    return datetime.date(year=year, month=month, day=1)
+
+
+def end_of_month(month, year=DEFAULT_YEAR):
+    if month == 12:
+        return datetime.date(year=year, month=month, day=31)
+    return datetime.date(year=year, month=month + 1, day=1) - datetime.timedelta(days=1)
+
+
+def _encode_list_of_ids(ids):
+    if not (ids and isinstance(ids, list)):
+        return ids
+    return ",".join([str(id_) for id_ in ids])
+
+
+def _post_to_api(
+    client,
+    resource_id,
+    target_resources,
+    *,
+    replace: bool = None,
+    date_period_ids=None,
+):
+    url = reverse("resource-copy-date-periods", kwargs={"pk": resource_id})
+
+    data = {
+        "target_resources": _encode_list_of_ids(target_resources),
+    }
+    if replace is not None:
+        data["replace"] = replace
+    if date_period_ids is not None:
+        data["date_period_ids"] = _encode_list_of_ids(date_period_ids)
+
+    response = client.post(url, QUERY_STRING=urlencode(data))
+
+    return response
+
+
+def assert_response_status_code(response, expected_status_code):
+    """
+    Assert that the response has the expected status code and print the response data if it doesn't.
+    """
+    assert response.status_code == expected_status_code, "{} {}".format(
+        response.status_code, response.data
+    )
+
+
+def assert_all_date_period_opening_hours_in_resource_opening_hours(
+    resource,
+    date_period,
+    start_date=DEFAULT_START_OF_YEAR,
+    end_date=DEFAULT_END_OF_YEAR,
+):
+    """
+    Assert that all the date period's opening hours are found in resource's opening hours.
+    """
+    date_period_opening_hours = date_period.get_daily_opening_hours(
+        start_date=start_date, end_date=end_date
+    )
+    resource_opening_hours = resource.get_daily_opening_hours(
+        start_date=start_date, end_date=end_date
+    )
+
+    for date in date_period_opening_hours:
+        assert date in resource_opening_hours
+        assert (
+            date_period_opening_hours[date] == resource_opening_hours[date]
+        ), f"Resource opening hours for date {date} should match date period opening hours"
+
+
+def assert_date_period_opening_hours_not_in_resource_opening_hours(
+    resource,
+    date_period,
+    start_date=DEFAULT_START_OF_YEAR,
+    end_date=DEFAULT_END_OF_YEAR,
+):
+    """
+    Assert that none of the date period's opening hours are found in resource's opening hours.
+    """
+    date_period_opening_hours = date_period.get_daily_opening_hours(
+        start_date=start_date, end_date=end_date
+    )
+    resource_opening_hours = resource.get_daily_opening_hours(
+        start_date=start_date, end_date=end_date
+    )
+
+    for date in date_period_opening_hours:
+        if date in resource_opening_hours:
+            assert (
+                date_period_opening_hours[date] != resource_opening_hours[date]
+            ), f"Resource opening hours for date {date} should not match date period opening hours"
+
 
 def create_test_periods(resource):
     date_period = DatePeriodFactory(
@@ -55,6 +153,41 @@ def create_test_periods(resource):
     )
 
 
+class TimeSpanGroupBuilder:
+    """
+    Helper class for building TimeSpanGroups.
+
+    Usage:
+    TimeSpanGroupBuilder(date_period).with_rule(...).with_time_span(...).create()
+    """
+
+    def __init__(self, date_period):
+        self.date_period = date_period
+        self.time_spans = []
+        self.rule = None
+
+    def with_rule(self, **kwargs):
+        kwargs.setdefault("context", RuleContext.PERIOD)
+        kwargs.setdefault("subject", RuleSubject.DAY)
+        self.rule = kwargs
+        return self
+
+    def with_time_span(self, **kwargs):
+        self.time_spans.append(kwargs)
+        return self
+
+    def create(self):
+        time_span_group = TimeSpanGroupFactory(period=self.date_period)
+
+        if self.rule is not None:
+            RuleFactory(group=time_span_group, **self.rule)
+
+        for time_span in self.time_spans:
+            TimeSpanFactory(group=time_span_group, **time_span)
+
+        return time_span_group
+
+
 def check_opening_hours_same(resource1, resource2, start_date, end_date):
     resource2.refresh_from_db()
     resource1_opening_hours = resource1.get_daily_opening_hours(start_date, end_date)
@@ -79,7 +212,7 @@ def test_copy_all_periods_to_resource_copy_to_self_prevented(resource):
     create_test_periods(resource)
 
     assert resource.date_periods.count() == 1
-    resource.copy_all_periods_to_resource(resource)
+    resource.copy_periods_to_resource(resource)
     assert resource.date_periods.count() == 1
 
 
@@ -90,7 +223,7 @@ def test_copy_all_periods_to_resource(
 ):
     create_test_periods(resource)
     resource2 = resource_factory()
-    resource.copy_all_periods_to_resource(resource2)
+    resource.copy_periods_to_resource(resource2)
 
     assert resource2.date_periods.count() == 1
     check_opening_hours_same(
@@ -120,7 +253,7 @@ def test_copy_all_periods_to_resource_replace(
         override=True,
     )
 
-    resource.copy_all_periods_to_resource(resource2, replace=replace)
+    resource.copy_periods_to_resource(resource2, replace=replace)
 
     if replace:
         assert resource2.date_periods.count() == 1
@@ -201,6 +334,213 @@ def test_copy_all_periods_to_resource_replace(
 
 
 # API
+
+
+@pytest.mark.django_db
+def test_copy_periods_to_resource_with_period_ids_and_replace(
+    admin_client,
+    resource_factory,
+    date_period_factory,
+):
+    # Create the source resource with two date periods.
+    source_resource = resource_factory()
+    create_test_periods(source_resource)
+    TimeSpanGroupBuilder(
+        date_period_factory(
+            resource=source_resource,
+            resource_state=State.OPEN,
+            start_date=DEFAULT_START_OF_YEAR,
+            end_date=DEFAULT_END_OF_YEAR,
+        )
+    ).with_time_span(
+        start_time=datetime.time(8),
+        end_time=datetime.time(16),
+        weekdays=Weekday.business_days(),
+    ).with_time_span(
+        start_time=datetime.time(10),
+        end_time=datetime.time(14),
+        weekdays=Weekday.weekend(),
+    ).create()
+
+    TimeSpanGroupBuilder(
+        summer_date_period := date_period_factory(
+            resource=source_resource,
+            resource_state=State.OPEN,
+            start_date=start_of_month(6),
+            end_date=end_of_month(8),
+            override=True,
+        )
+    ).with_time_span(
+        start_time=datetime.time(10),
+        end_time=datetime.time(12),
+        weekdays=Weekday.business_days(),
+    ).create()
+
+    target_resource = resource_factory()
+    date_period_factory(
+        resource=target_resource,
+        resource_state=State.CLOSED,
+        start_date=DEFAULT_START_OF_YEAR,
+        end_date=DEFAULT_END_OF_YEAR,
+    )
+
+    # Copy the summer date period from the source resource to the target resource.
+    response = _post_to_api(
+        admin_client,
+        source_resource.id,
+        target_resource.id,
+        date_period_ids=[summer_date_period.id],
+        replace=True,
+    )
+
+    assert_response_status_code(response, 200)
+
+    target_resource.refresh_from_db()
+
+    # Assert that the target resource has only the source resource's summer date period.
+    assert target_resource.date_periods.count() == 1
+
+    summer_period_opening_hours = summer_date_period.get_daily_opening_hours(
+        DEFAULT_START_OF_YEAR, DEFAULT_END_OF_YEAR
+    )
+    target_resource_opening_hours = target_resource.get_daily_opening_hours(
+        DEFAULT_START_OF_YEAR, DEFAULT_END_OF_YEAR
+    )
+
+    assert target_resource_opening_hours == summer_period_opening_hours
+    assert summer_date_period.as_text() in target_resource.date_periods_as_text
+
+    # Paranoia check: shouldn't copy every date period from the source resource.
+    assert target_resource.date_periods_hash != source_resource.date_periods_hash
+
+
+@pytest.mark.django_db
+def test_copy_periods_to_resource_with_period_ids(
+    admin_client,
+    resource_factory,
+    date_period_factory,
+):
+    # Create the source resource with two date periods.
+    source_resource = resource_factory()
+    TimeSpanGroupBuilder(
+        first_date_period := date_period_factory(
+            resource=source_resource,
+            resource_state=State.OPEN,
+            start_date=DEFAULT_START_OF_YEAR,
+            end_date=DEFAULT_END_OF_YEAR,
+        )
+    ).with_time_span(
+        start_time=datetime.time(8),
+        end_time=datetime.time(16),
+        weekdays=Weekday.business_days(),
+    ).with_time_span(
+        start_time=datetime.time(10),
+        end_time=datetime.time(14),
+        weekdays=Weekday.weekend(),
+    ).create()
+
+    TimeSpanGroupBuilder(
+        second_date_period := date_period_factory(
+            resource=source_resource,
+            resource_state=State.OPEN,
+            start_date=start_of_month(6),
+            end_date=end_of_month(8),
+            override=True,
+        )
+    ).with_time_span(
+        start_time=datetime.time(10),
+        end_time=datetime.time(12),
+        weekdays=Weekday.business_days(),
+    ).create()
+
+    # Create the target resource with one date period.
+    target_resource = resource_factory()
+    target_resource_date_period = date_period_factory(
+        resource=target_resource,
+        resource_state=State.CLOSED,
+        start_date=datetime.date(year=2020, month=1, day=1),
+        end_date=datetime.date(year=2020, month=12, day=31),
+    )
+
+    # Copy the second date period to the target resource.
+    response = _post_to_api(
+        admin_client,
+        source_resource.id,
+        target_resource.id,
+        date_period_ids=[second_date_period.id],
+    )
+
+    assert_response_status_code(response, 200)
+
+    target_resource.refresh_from_db()
+
+    # Assert that the target resource has its original date period and the source resource's second date period.
+    assert target_resource.date_periods.count() == 2
+    assert_all_date_period_opening_hours_in_resource_opening_hours(
+        target_resource, second_date_period
+    )
+    assert second_date_period.as_text() in target_resource.date_periods_as_text
+    assert target_resource_date_period.as_text() in target_resource.date_periods_as_text
+    # Paranoia check: assert that the target resource does not have the source resource's first date period.
+    assert first_date_period.as_text() not in target_resource.date_periods_as_text
+    assert_date_period_opening_hours_not_in_resource_opening_hours(
+        target_resource, first_date_period
+    )
+
+
+@pytest.mark.parametrize(
+    "date_period_ids",
+    [
+        [-1],
+        [-1, -2],
+    ],
+)
+@pytest.mark.django_db
+def test_copy_periods_to_resource_with_period_ids_all_missing(
+    date_period_ids,
+    admin_client,
+    resource_factory,
+):
+    source_resource = resource_factory()
+    target_resource = resource_factory()
+
+    response = _post_to_api(
+        admin_client,
+        source_resource.id,
+        target_resource.id,
+        date_period_ids=date_period_ids,
+    )
+
+    assert_response_status_code(response, 404)
+
+
+@pytest.mark.parametrize(
+    "date_period_ids",
+    [
+        [-1],
+        [-1, -2],
+    ],
+)
+@pytest.mark.django_db
+def test_copy_periods_to_resource_with_period_ids_some_missing(
+    date_period_ids,
+    admin_client,
+    resource_factory,
+    date_period_factory,
+):
+    source_resource = resource_factory()
+    target_resource = resource_factory()
+    date_periods = date_period_factory.create_batch(10, resource=source_resource)
+
+    response = _post_to_api(
+        admin_client,
+        source_resource.id,
+        target_resource.id,
+        date_period_ids=date_period_ids
+        + [date_period.id for date_period in date_periods],
+    )
+
+    assert_response_status_code(response, 404)
 
 
 @pytest.mark.django_db

--- a/hours/tests/test_utils.py
+++ b/hours/tests/test_utils.py
@@ -1,0 +1,39 @@
+from unittest import mock
+
+import pytest
+
+from hours.utils import copy_instance
+
+
+def test_copy_instance_saves_and_returns_new_instance():
+    instance = mock.MagicMock(id=1)
+
+    new_instance = copy_instance(instance)
+
+    assert new_instance.id != instance.id
+    assert new_instance.id is None
+    new_instance.save.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "field_overrides",
+    [
+        {},
+        {"name": "Test"},
+        {"name": "Test", "description": "Test description"},
+    ],
+)
+def test_copy_instance_returns_new_instance_with_correct_field_values_when_field_overrides_is_used(
+    field_overrides,
+):
+    instance = mock.MagicMock()
+    for field_name in field_overrides.keys():
+        setattr(instance, field_name, "Old value")
+
+    new_instance = copy_instance(instance, field_overrides)
+
+    for field_name, field_value in field_overrides.items():
+        # Old resource is not changed
+        assert getattr(instance, field_name) != field_value
+        # New resource has correct field value
+        assert getattr(new_instance, field_name) == field_value

--- a/hours/utils.py
+++ b/hours/utils.py
@@ -1,3 +1,11 @@
+from copy import deepcopy
+from typing import TypeVar
+
+from django.db import models
+
+T = TypeVar("T", bound=models.Model)
+
+
 def get_resource_pk_filter(pk):
     if ":" not in pk:
         return {"pk": pk}
@@ -8,3 +16,13 @@ def get_resource_pk_filter(pk):
         "origins__data_source_id": data_source_id,
         "origins__origin_id": origin_id,
     }
+
+
+def copy_instance(instance: T, field_overrides: dict = None) -> T:
+    new_instance = deepcopy(instance)
+    new_instance.id = None
+    for field_name, field_value in (field_overrides or {}).items():
+        setattr(new_instance, field_name, field_value)
+    new_instance.save()
+
+    return new_instance


### PR DESCRIPTION
Add a new query parameter `date_period_ids` in the `/v1/resource/{id}/copy_date_periods/` endpoint, which accepts a comma-separated list of date period ids for specifying which date periods to copy to the target resource.

Also did some refactoring on the `copy_date_periods` tests.