### PR TITLE
Run makemessages, fix typo, remove init_application.sh

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -48,7 +48,7 @@ if [[ "$APPLY_MIGRATIONS" = "true" ]]; then
 fi
 if [[ "$INITIAL_TEST_DATA" = "true" ]]; then
     echo "Apply initial test data"
-    deploy/init_application.sh
+    ./manage.py create_e2e_test_data
 fi
 
 if [[ "$1" = "start_django_development_server" ]]; then
@@ -64,8 +64,6 @@ elif [[ "$1" = "initial_data" ]]; then
 elif [[ "$1" = "migrate" ]]; then
     _log_boxed "Running migrations"
     ./manage.py migrate
-    _log_boxed "Updating language fields & installing templates"
-    deploy/init_application.sh
 elif [[ "$1" = "test" ]]; then
     _log_boxed "Running flake8"
     flake8

--- a/deploy/init_application.sh
+++ b/deploy/init_application.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# This file is for any extra management commands Hauki needs to initialize after migrations
-
-set -e
-
-./manage.py compilemessages
-./manage.py create_e2e_test_data

--- a/hours/viewsets.py
+++ b/hours/viewsets.py
@@ -744,7 +744,7 @@ class DatePeriodViewSet(
         ):
             raise ValidationError(
                 detail=_(
-                    "resource, start_date or end_date GET parameter is required to"
+                    "resource, start_date or end_date GET parameter is required to "
                     "list date periods"
                 )
             )

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-21 11:48+0200\n"
+"POT-Creation-Date: 2024-04-05 10:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,19 +38,19 @@ msgstr ""
 msgid "Period name"
 msgstr ""
 
-#: hours/admin.py:143 hours/models.py:335
+#: hours/admin.py:143 hours/models.py:380
 msgid "Resource"
 msgstr ""
 
-#: hours/admin.py:148 hours/models.py:634
+#: hours/admin.py:148 hours/models.py:644
 msgid "Start date"
 msgstr ""
 
-#: hours/admin.py:153 hours/models.py:637
+#: hours/admin.py:153 hours/models.py:647
 msgid "End date"
 msgstr ""
 
-#: hours/admin.py:158 hours/models.py:641 hours/models.py:911
+#: hours/admin.py:158 hours/models.py:651 hours/models.py:939
 msgid "Resource state"
 msgstr ""
 
@@ -445,89 +445,89 @@ msgctxt "FrequencyModifier"
 msgid "Odd"
 msgstr ""
 
-#: hours/models.py:254 hours/models.py:281 hours/models.py:630
-#: hours/models.py:887 hours/models.py:1017
+#: hours/models.py:299 hours/models.py:326 hours/models.py:640
+#: hours/models.py:915 hours/models.py:1047
 msgid "Name"
 msgstr ""
 
-#: hours/models.py:255 hours/models.py:283 hours/models.py:632
-#: hours/models.py:889 hours/models.py:1019
+#: hours/models.py:300 hours/models.py:328 hours/models.py:642
+#: hours/models.py:917 hours/models.py:1049
 msgid "Description"
 msgstr ""
 
-#: hours/models.py:257
+#: hours/models.py:302
 msgid "Organizations may be edited by users"
 msgstr ""
 
-#: hours/models.py:260
+#: hours/models.py:305
 msgid "Resources may be edited by users"
 msgstr ""
 
-#: hours/models.py:264
+#: hours/models.py:309
 msgid "Data source"
 msgstr ""
 
-#: hours/models.py:265
+#: hours/models.py:310
 msgid "Data sources"
 msgstr ""
 
-#: hours/models.py:284
+#: hours/models.py:329
 msgid "Street address"
 msgstr ""
 
-#: hours/models.py:287
+#: hours/models.py:332
 msgid "Resource type"
 msgstr ""
 
-#: hours/models.py:293
+#: hours/models.py:338
 msgid "Sub resources"
 msgstr ""
 
-#: hours/models.py:313
+#: hours/models.py:358
 msgid "Extra data"
 msgstr ""
 
-#: hours/models.py:336
+#: hours/models.py:381
 msgid "Resources"
 msgstr ""
 
-#: hours/models.py:381
+#: hours/models.py:426
 msgctxt "periods_as_text_separator"
 msgid ""
 "\n"
 "========================================\n"
 msgstr ""
 
-#: hours/models.py:387
+#: hours/models.py:432
 #, python-brace-format
 msgid "{separator}{date_periods}{separator}"
 msgstr ""
 
-#: hours/models.py:608 hours/models.py:815 users/models.py:38
+#: hours/models.py:618 hours/models.py:843 users/models.py:38
 msgid "Origin ID"
 msgstr ""
 
-#: hours/models.py:612
+#: hours/models.py:622
 msgid "Resource origin"
 msgstr ""
 
-#: hours/models.py:613
+#: hours/models.py:623
 msgid "Resource origins"
 msgstr ""
 
-#: hours/models.py:646
+#: hours/models.py:656
 msgid "Override"
 msgstr ""
 
-#: hours/models.py:652
+#: hours/models.py:662
 msgid "Period"
 msgstr ""
 
-#: hours/models.py:653
+#: hours/models.py:663
 msgid "Periods"
 msgstr ""
 
-#: hours/models.py:698
+#: hours/models.py:723
 msgid ""
 "\n"
 "\n"
@@ -535,11 +535,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: hours/models.py:708
+#: hours/models.py:734
 msgid "Not specified"
 msgstr ""
 
-#: hours/models.py:721
+#: hours/models.py:747
 #, python-brace-format
 msgid ""
 "{name}{description}Date period: {dates}\n"
@@ -548,210 +548,210 @@ msgid ""
 "{time_span_groups}\n"
 msgstr ""
 
-#: hours/models.py:819
+#: hours/models.py:847
 msgid "Period origin"
 msgstr ""
 
-#: hours/models.py:820
+#: hours/models.py:848
 msgid "Period origins"
 msgstr ""
 
-#: hours/models.py:875
+#: hours/models.py:903
 msgid ""
 "\n"
 "\n"
 " In effect when every one of these match:\n"
 msgstr ""
 
-#: hours/models.py:891
+#: hours/models.py:919
 msgid "Start time"
 msgstr ""
 
-#: hours/models.py:894
+#: hours/models.py:922
 msgid "End time"
 msgstr ""
 
-#: hours/models.py:897
+#: hours/models.py:925
 msgid "Is end time on the next day"
 msgstr ""
 
-#: hours/models.py:899
+#: hours/models.py:927
 msgid "24 hours"
 msgstr ""
 
-#: hours/models.py:903
+#: hours/models.py:931
 msgid "Weekday"
 msgstr ""
 
-#: hours/models.py:917
+#: hours/models.py:945
 msgid "Time span"
 msgstr ""
 
-#: hours/models.py:918
+#: hours/models.py:946
 msgid "Time spans"
 msgstr ""
 
-#: hours/models.py:957
+#: hours/models.py:985
 msgctxt "timespan_as_text"
 msgid "Every day"
 msgstr ""
 
-#: hours/models.py:984
+#: hours/models.py:1012
 msgctxt "timespan_as_text"
 msgid "The whole day"
 msgstr ""
 
-#: hours/models.py:986
+#: hours/models.py:1014
 #, python-brace-format
 msgctxt "timespan_as_text"
 msgid "{start_time}-{end_time}"
 msgstr ""
 
-#: hours/models.py:1003
+#: hours/models.py:1033
 #, python-brace-format
 msgctxt "timespan_as_text"
 msgid "{weekdays} {times} {state}{description}"
 msgstr ""
 
-#: hours/models.py:1022
+#: hours/models.py:1052
 msgid "Context"
 msgstr ""
 
-#: hours/models.py:1027
+#: hours/models.py:1057
 msgid "Subject"
 msgstr ""
 
-#: hours/models.py:1030
+#: hours/models.py:1060
 msgid "Start"
 msgstr ""
 
-#: hours/models.py:1032
+#: hours/models.py:1062
 msgid "Frequency (ordinal)"
 msgstr ""
 
-#: hours/models.py:1036
+#: hours/models.py:1066
 msgid "Frequency (modifier)"
 msgstr ""
 
-#: hours/models.py:1043
+#: hours/models.py:1073
 msgid "Rule"
 msgstr ""
 
-#: hours/models.py:1044
+#: hours/models.py:1074
 msgid "Rules"
 msgstr ""
 
-#: hours/models.py:1074
+#: hours/models.py:1104
 msgctxt "rule_as_text_context"
 msgid "the period"
 msgstr ""
 
-#: hours/models.py:1076
+#: hours/models.py:1106
 #, python-brace-format
 msgctxt "rule_as_text_context"
 msgid "every {context}"
 msgstr ""
 
-#: hours/models.py:1082
+#: hours/models.py:1112
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "{nth} {subject} in {context}"
 msgstr ""
 
-#: hours/models.py:1091
+#: hours/models.py:1121
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "starting from the {nth} {last} {subject}"
 msgstr ""
 
-#: hours/models.py:1094
+#: hours/models.py:1124
 msgctxt "starting_from_the_last"
 msgid "last"
 msgstr ""
 
-#: hours/models.py:1104
+#: hours/models.py:1134
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "Every {nth} {subject} in {context} {starting_from_text}"
 msgstr ""
 
-#: hours/models.py:1115
+#: hours/models.py:1145
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "On {modifier} {subject}s in {context}"
 msgstr ""
 
-#: hours/models.py:1136
+#: hours/models.py:1166
 msgid ""
 "We cannot start counting from period start in an infinite period. Please "
 "select shorter context for your rule."
 msgstr ""
 
-#: hours/models.py:1141
+#: hours/models.py:1171
 msgid "Subject must be a shorter timespan than context."
 msgstr ""
 
-#: hours/models.py:1145
+#: hours/models.py:1175
 msgid ""
 "You cannot add a rule with both even/odd and another frequency at the same "
 "time."
 msgstr ""
 
-#: hours/models.py:1154
+#: hours/models.py:1184
 msgid ""
 "Rule can only start from zero if starting from zeroth ISO week of the year. "
 "All other rules start counting from 1. Use negative numbers to count from "
 "the end of the context."
 msgstr ""
 
-#: hours/models.py:1162
+#: hours/models.py:1192
 msgid ""
 "Even/odd subjects are not counted starting from a specific time. If you wish "
 "to have an alternating rule starting from a specific time, please use "
 "frequency_ordinal=2 with start=1 or start=2."
 msgstr ""
 
-#: hours/models.py:1429
+#: hours/models.py:1459
 msgid "Signature"
 msgstr ""
 
-#: hours/models.py:1430
+#: hours/models.py:1460
 msgid "Signature created at"
 msgstr ""
 
-#: hours/models.py:1431
+#: hours/models.py:1461
 msgid "Signature valid until"
 msgstr ""
 
-#: hours/models.py:1433
+#: hours/models.py:1463
 msgid "Invalidated time"
 msgstr ""
 
-#: hours/models.py:1437
+#: hours/models.py:1467
 msgid "Signed auth entry"
 msgstr ""
 
-#: hours/models.py:1438
+#: hours/models.py:1468
 msgid "Signed auth entries"
 msgstr ""
 
-#: hours/models.py:1443
+#: hours/models.py:1473
 msgid "Signing key"
 msgstr ""
 
-#: hours/models.py:1444
+#: hours/models.py:1474
 msgid "Key valid after"
 msgstr ""
 
-#: hours/models.py:1446
+#: hours/models.py:1476
 msgid "Key valid until"
 msgstr ""
 
-#: hours/models.py:1450
+#: hours/models.py:1480
 msgid "Signed auth key"
 msgstr ""
 
-#: hours/models.py:1451
+#: hours/models.py:1481
 msgid "Signed auth keys"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 msgid "All data from data source {self.instance.id} is read-only."
 msgstr ""
 
-#: hours/serializers.py:352 hours/serializers.py:363
+#: hours/serializers.py:351 hours/serializers.py:362
 msgid ""
 "Cannot create or edit sub resources of a resource in an organisation the "
 "user is not part of "
@@ -798,33 +798,37 @@ msgstr ""
 msgid "start_date must be before end_date"
 msgstr ""
 
-#: hours/viewsets.py:555
+#: hours/viewsets.py:563
 msgid "target_resources parameter is required"
 msgstr ""
 
-#: hours/viewsets.py:579
+#: hours/viewsets.py:587
 msgid "Resource with the id \"{}\" not found."
 msgstr ""
 
-#: hours/viewsets.py:585
+#: hours/viewsets.py:593
 msgid "Can't copy date periods to self"
 msgstr ""
 
-#: hours/viewsets.py:597
+#: hours/viewsets.py:605
 msgid "No permission to modify resource(s): {}"
 msgstr ""
 
-#: hours/viewsets.py:707
+#: hours/viewsets.py:628
+msgid "Date periods not found: {}"
+msgstr ""
+
+#: hours/viewsets.py:747
 msgid ""
 "resource, start_date or end_date GET parameter is required to list date "
 "periods"
 msgstr ""
 
-#: hours/viewsets.py:757
+#: hours/viewsets.py:797
 msgid "resource GET parameter is required to list rules of resources"
 msgstr ""
 
-#: hours/viewsets.py:799
+#: hours/viewsets.py:839
 msgid "resource GET parameter is required to list time spans of resources"
 msgstr ""
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-21 11:48+0200\n"
+"POT-Creation-Date: 2024-04-05 10:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,19 +37,19 @@ msgstr ""
 msgid "Period name"
 msgstr "Jakson nimi"
 
-#: hours/admin.py:143 hours/models.py:335
+#: hours/admin.py:143 hours/models.py:380
 msgid "Resource"
 msgstr "Resurssi"
 
-#: hours/admin.py:148 hours/models.py:634
+#: hours/admin.py:148 hours/models.py:644
 msgid "Start date"
 msgstr "Alkupäivämäärä"
 
-#: hours/admin.py:153 hours/models.py:637
+#: hours/admin.py:153 hours/models.py:647
 msgid "End date"
 msgstr "Loppupäivämäärä"
 
-#: hours/admin.py:158 hours/models.py:641 hours/models.py:911
+#: hours/admin.py:158 hours/models.py:651 hours/models.py:939
 msgid "Resource state"
 msgstr "Resurssin tila"
 
@@ -411,89 +411,89 @@ msgctxt "FrequencyModifier"
 msgid "Odd"
 msgstr "Pariton"
 
-#: hours/models.py:254 hours/models.py:281 hours/models.py:630
-#: hours/models.py:887 hours/models.py:1017
+#: hours/models.py:299 hours/models.py:326 hours/models.py:640
+#: hours/models.py:915 hours/models.py:1047
 msgid "Name"
 msgstr "Nimi"
 
-#: hours/models.py:255 hours/models.py:283 hours/models.py:632
-#: hours/models.py:889 hours/models.py:1019
+#: hours/models.py:300 hours/models.py:328 hours/models.py:642
+#: hours/models.py:917 hours/models.py:1049
 msgid "Description"
 msgstr "Kuvaus"
 
-#: hours/models.py:257
+#: hours/models.py:302
 msgid "Organizations may be edited by users"
 msgstr ""
 
-#: hours/models.py:260
+#: hours/models.py:305
 msgid "Resources may be edited by users"
 msgstr ""
 
-#: hours/models.py:264
+#: hours/models.py:309
 msgid "Data source"
 msgstr "Lähdejärjestelmä"
 
-#: hours/models.py:265
+#: hours/models.py:310
 msgid "Data sources"
 msgstr "Lähdejärjestelmät"
 
-#: hours/models.py:284
+#: hours/models.py:329
 msgid "Street address"
 msgstr "Katuosoite"
 
-#: hours/models.py:287
+#: hours/models.py:332
 msgid "Resource type"
 msgstr "Resurssin tyyppi"
 
-#: hours/models.py:293
+#: hours/models.py:338
 msgid "Sub resources"
 msgstr "Aliresurssit"
 
-#: hours/models.py:313
+#: hours/models.py:358
 msgid "Extra data"
 msgstr "Lisätiedot"
 
-#: hours/models.py:336
+#: hours/models.py:381
 msgid "Resources"
 msgstr "Resurssit"
 
-#: hours/models.py:381
+#: hours/models.py:426
 msgctxt "periods_as_text_separator"
 msgid ""
 "\n"
 "========================================\n"
 msgstr ""
 
-#: hours/models.py:387
+#: hours/models.py:432
 #, python-brace-format
 msgid "{separator}{date_periods}{separator}"
 msgstr ""
 
-#: hours/models.py:608 hours/models.py:815 users/models.py:38
+#: hours/models.py:618 hours/models.py:843 users/models.py:38
 msgid "Origin ID"
 msgstr "Tunniste lähdejärjestelmässä"
 
-#: hours/models.py:612
+#: hours/models.py:622
 msgid "Resource origin"
 msgstr "Resurssin lähde"
 
-#: hours/models.py:613
+#: hours/models.py:623
 msgid "Resource origins"
 msgstr "Resurssin lähteet"
 
-#: hours/models.py:646
+#: hours/models.py:656
 msgid "Override"
 msgstr "Yliajo"
 
-#: hours/models.py:652
+#: hours/models.py:662
 msgid "Period"
 msgstr "Jakso"
 
-#: hours/models.py:653
+#: hours/models.py:663
 msgid "Periods"
 msgstr "Jaksot"
 
-#: hours/models.py:698
+#: hours/models.py:723
 msgid ""
 "\n"
 "\n"
@@ -501,11 +501,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: hours/models.py:708
+#: hours/models.py:734
 msgid "Not specified"
 msgstr "Ei määritelty"
 
-#: hours/models.py:721
+#: hours/models.py:747
 #, python-brace-format
 msgid ""
 "{name}{description}Date period: {dates}\n"
@@ -518,15 +518,15 @@ msgstr ""
 "\n"
 "{time_span_groups}\n"
 
-#: hours/models.py:819
+#: hours/models.py:847
 msgid "Period origin"
 msgstr "Jakson lähde"
 
-#: hours/models.py:820
+#: hours/models.py:848
 msgid "Period origins"
 msgstr "Jakson lähteet"
 
-#: hours/models.py:875
+#: hours/models.py:903
 msgid ""
 "\n"
 "\n"
@@ -536,51 +536,51 @@ msgstr ""
 "\n"
 " Voimassa kun kaikki seuraavat pätevät:\n"
 
-#: hours/models.py:891
+#: hours/models.py:919
 msgid "Start time"
 msgstr "Alkuaika"
 
-#: hours/models.py:894
+#: hours/models.py:922
 msgid "End time"
 msgstr "Loppuaika"
 
-#: hours/models.py:897
+#: hours/models.py:925
 msgid "Is end time on the next day"
 msgstr ""
 
-#: hours/models.py:899
+#: hours/models.py:927
 msgid "24 hours"
 msgstr "24 tuntia"
 
-#: hours/models.py:903
+#: hours/models.py:931
 msgid "Weekday"
 msgstr "Viikonpäivä"
 
-#: hours/models.py:917
+#: hours/models.py:945
 msgid "Time span"
 msgstr "Aikaväli"
 
-#: hours/models.py:918
+#: hours/models.py:946
 msgid "Time spans"
 msgstr "Aikavälit"
 
-#: hours/models.py:957
+#: hours/models.py:985
 msgctxt "timespan_as_text"
 msgid "Every day"
 msgstr "Joka päivä"
 
-#: hours/models.py:984
+#: hours/models.py:1012
 msgctxt "timespan_as_text"
 msgid "The whole day"
 msgstr "Koko päivän"
 
-#: hours/models.py:986
+#: hours/models.py:1014
 #, python-brace-format
 msgctxt "timespan_as_text"
 msgid "{start_time}-{end_time}"
 msgstr "{start_time}-{end_time}"
 
-#: hours/models.py:1003
+#: hours/models.py:1033
 #, fuzzy, python-brace-format
 #| msgctxt "timespan_as_text"
 #| msgid "{weekdays} {times} {state}"
@@ -588,145 +588,145 @@ msgctxt "timespan_as_text"
 msgid "{weekdays} {times} {state}{description}"
 msgstr "{weekdays} {times} {state}"
 
-#: hours/models.py:1022
+#: hours/models.py:1052
 msgid "Context"
 msgstr "Konteksti"
 
-#: hours/models.py:1027
+#: hours/models.py:1057
 msgid "Subject"
 msgstr "Kohde"
 
-#: hours/models.py:1030
+#: hours/models.py:1060
 msgid "Start"
 msgstr "Alku"
 
-#: hours/models.py:1032
+#: hours/models.py:1062
 msgid "Frequency (ordinal)"
 msgstr "Toistuvuus (järjestysnumero)"
 
-#: hours/models.py:1036
+#: hours/models.py:1066
 msgid "Frequency (modifier)"
 msgstr "Toistuvuus (määre)"
 
-#: hours/models.py:1043
+#: hours/models.py:1073
 msgid "Rule"
 msgstr "Sääntö"
 
-#: hours/models.py:1044
+#: hours/models.py:1074
 msgid "Rules"
 msgstr "Säännöt"
 
-#: hours/models.py:1074
+#: hours/models.py:1104
 msgctxt "rule_as_text_context"
 msgid "the period"
 msgstr "Jakson"
 
-#: hours/models.py:1076
+#: hours/models.py:1106
 #, python-brace-format
 msgctxt "rule_as_text_context"
 msgid "every {context}"
 msgstr "Jokaisen {context}"
 
-#: hours/models.py:1082
+#: hours/models.py:1112
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "{nth} {subject} in {context}"
 msgstr "{context} {nth} {subject}"
 
-#: hours/models.py:1091
+#: hours/models.py:1121
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "starting from the {nth} {last} {subject}"
 msgstr "alkaen {nth} {last} {subject}"
 
-#: hours/models.py:1094
+#: hours/models.py:1124
 msgctxt "starting_from_the_last"
 msgid "last"
 msgstr "viimeisestä"
 
-#: hours/models.py:1104
+#: hours/models.py:1134
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "Every {nth} {subject} in {context} {starting_from_text}"
 msgstr "{context} joka {nth} {subject} {starting_from_text}"
 
-#: hours/models.py:1115
+#: hours/models.py:1145
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "On {modifier} {subject}s in {context}"
 msgstr "{context} jokainen {modifier} {subject}"
 
-#: hours/models.py:1136
+#: hours/models.py:1166
 msgid ""
 "We cannot start counting from period start in an infinite period. Please "
 "select shorter context for your rule."
 msgstr ""
 
-#: hours/models.py:1141
+#: hours/models.py:1171
 msgid "Subject must be a shorter timespan than context."
 msgstr ""
 
-#: hours/models.py:1145
+#: hours/models.py:1175
 msgid ""
 "You cannot add a rule with both even/odd and another frequency at the same "
 "time."
 msgstr ""
 
-#: hours/models.py:1154
+#: hours/models.py:1184
 msgid ""
 "Rule can only start from zero if starting from zeroth ISO week of the year. "
 "All other rules start counting from 1. Use negative numbers to count from "
 "the end of the context."
 msgstr ""
 
-#: hours/models.py:1162
+#: hours/models.py:1192
 msgid ""
 "Even/odd subjects are not counted starting from a specific time. If you wish "
 "to have an alternating rule starting from a specific time, please use "
 "frequency_ordinal=2 with start=1 or start=2."
 msgstr ""
 
-#: hours/models.py:1429
+#: hours/models.py:1459
 msgid "Signature"
 msgstr "Allekirjoitus"
 
-#: hours/models.py:1430
+#: hours/models.py:1460
 msgid "Signature created at"
 msgstr "Allekirjoituksen luontiaika"
 
-#: hours/models.py:1431
+#: hours/models.py:1461
 msgid "Signature valid until"
 msgstr "Allekirjoituksen vanhenemisaika"
 
-#: hours/models.py:1433
+#: hours/models.py:1463
 msgid "Invalidated time"
 msgstr "Mitätöintiaika"
 
-#: hours/models.py:1437
+#: hours/models.py:1467
 msgid "Signed auth entry"
 msgstr ""
 
-#: hours/models.py:1438
+#: hours/models.py:1468
 msgid "Signed auth entries"
 msgstr ""
 
-#: hours/models.py:1443
+#: hours/models.py:1473
 msgid "Signing key"
 msgstr "Allekirjoitusavain"
 
-#: hours/models.py:1444
+#: hours/models.py:1474
 msgid "Key valid after"
 msgstr "Avaimen voimassaoloaika alkaa"
 
-#: hours/models.py:1446
+#: hours/models.py:1476
 msgid "Key valid until"
 msgstr "Avaimen voimassaoloaika loppuu"
 
-#: hours/models.py:1450
+#: hours/models.py:1480
 msgid "Signed auth key"
 msgstr ""
 
-#: hours/models.py:1451
+#: hours/models.py:1481
 msgid "Signed auth keys"
 msgstr ""
 
@@ -743,7 +743,7 @@ msgstr ""
 msgid "All data from data source {self.instance.id} is read-only."
 msgstr ""
 
-#: hours/serializers.py:352 hours/serializers.py:363
+#: hours/serializers.py:351 hours/serializers.py:362
 msgid ""
 "Cannot create or edit sub resources of a resource in an organisation the "
 "user is not part of "
@@ -773,33 +773,37 @@ msgstr "Viallinen loppupäivämäärä"
 msgid "start_date must be before end_date"
 msgstr ""
 
-#: hours/viewsets.py:555
+#: hours/viewsets.py:563
 msgid "target_resources parameter is required"
 msgstr ""
 
-#: hours/viewsets.py:579
+#: hours/viewsets.py:587
 msgid "Resource with the id \"{}\" not found."
 msgstr ""
 
-#: hours/viewsets.py:585
+#: hours/viewsets.py:593
 msgid "Can't copy date periods to self"
 msgstr ""
 
-#: hours/viewsets.py:597
+#: hours/viewsets.py:605
 msgid "No permission to modify resource(s): {}"
 msgstr ""
 
-#: hours/viewsets.py:707
+#: hours/viewsets.py:628
+msgid "Date periods not found: {}"
+msgstr ""
+
+#: hours/viewsets.py:747
 msgid ""
 "resource, start_date or end_date GET parameter is required to list date "
 "periods"
 msgstr ""
 
-#: hours/viewsets.py:757
+#: hours/viewsets.py:797
 msgid "resource GET parameter is required to list rules of resources"
 msgstr ""
 
-#: hours/viewsets.py:799
+#: hours/viewsets.py:839
 msgid "resource GET parameter is required to list time spans of resources"
 msgstr ""
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-21 11:48+0200\n"
+"POT-Creation-Date: 2024-04-05 10:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,19 +37,19 @@ msgstr ""
 msgid "Period name"
 msgstr ""
 
-#: hours/admin.py:143 hours/models.py:335
+#: hours/admin.py:143 hours/models.py:380
 msgid "Resource"
 msgstr ""
 
-#: hours/admin.py:148 hours/models.py:634
+#: hours/admin.py:148 hours/models.py:644
 msgid "Start date"
 msgstr ""
 
-#: hours/admin.py:153 hours/models.py:637
+#: hours/admin.py:153 hours/models.py:647
 msgid "End date"
 msgstr ""
 
-#: hours/admin.py:158 hours/models.py:641 hours/models.py:911
+#: hours/admin.py:158 hours/models.py:651 hours/models.py:939
 msgid "Resource state"
 msgstr ""
 
@@ -411,89 +411,89 @@ msgctxt "FrequencyModifier"
 msgid "Odd"
 msgstr "Udd"
 
-#: hours/models.py:254 hours/models.py:281 hours/models.py:630
-#: hours/models.py:887 hours/models.py:1017
+#: hours/models.py:299 hours/models.py:326 hours/models.py:640
+#: hours/models.py:915 hours/models.py:1047
 msgid "Name"
 msgstr ""
 
-#: hours/models.py:255 hours/models.py:283 hours/models.py:632
-#: hours/models.py:889 hours/models.py:1019
+#: hours/models.py:300 hours/models.py:328 hours/models.py:642
+#: hours/models.py:917 hours/models.py:1049
 msgid "Description"
 msgstr ""
 
-#: hours/models.py:257
+#: hours/models.py:302
 msgid "Organizations may be edited by users"
 msgstr ""
 
-#: hours/models.py:260
+#: hours/models.py:305
 msgid "Resources may be edited by users"
 msgstr ""
 
-#: hours/models.py:264
+#: hours/models.py:309
 msgid "Data source"
 msgstr ""
 
-#: hours/models.py:265
+#: hours/models.py:310
 msgid "Data sources"
 msgstr ""
 
-#: hours/models.py:284
+#: hours/models.py:329
 msgid "Street address"
 msgstr ""
 
-#: hours/models.py:287
+#: hours/models.py:332
 msgid "Resource type"
 msgstr ""
 
-#: hours/models.py:293
+#: hours/models.py:338
 msgid "Sub resources"
 msgstr ""
 
-#: hours/models.py:313
+#: hours/models.py:358
 msgid "Extra data"
 msgstr ""
 
-#: hours/models.py:336
+#: hours/models.py:381
 msgid "Resources"
 msgstr ""
 
-#: hours/models.py:381
+#: hours/models.py:426
 msgctxt "periods_as_text_separator"
 msgid ""
 "\n"
 "========================================\n"
 msgstr ""
 
-#: hours/models.py:387
+#: hours/models.py:432
 #, python-brace-format
 msgid "{separator}{date_periods}{separator}"
 msgstr ""
 
-#: hours/models.py:608 hours/models.py:815 users/models.py:38
+#: hours/models.py:618 hours/models.py:843 users/models.py:38
 msgid "Origin ID"
 msgstr ""
 
-#: hours/models.py:612
+#: hours/models.py:622
 msgid "Resource origin"
 msgstr ""
 
-#: hours/models.py:613
+#: hours/models.py:623
 msgid "Resource origins"
 msgstr ""
 
-#: hours/models.py:646
+#: hours/models.py:656
 msgid "Override"
 msgstr ""
 
-#: hours/models.py:652
+#: hours/models.py:662
 msgid "Period"
 msgstr ""
 
-#: hours/models.py:653
+#: hours/models.py:663
 msgid "Periods"
 msgstr ""
 
-#: hours/models.py:698
+#: hours/models.py:723
 msgid ""
 "\n"
 "\n"
@@ -501,11 +501,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: hours/models.py:708
+#: hours/models.py:734
 msgid "Not specified"
 msgstr "Ej fastställt"
 
-#: hours/models.py:721
+#: hours/models.py:747
 #, python-brace-format
 msgid ""
 "{name}{description}Date period: {dates}\n"
@@ -518,15 +518,15 @@ msgstr ""
 "\n"
 "{time_span_groups}\n"
 
-#: hours/models.py:819
+#: hours/models.py:847
 msgid "Period origin"
 msgstr ""
 
-#: hours/models.py:820
+#: hours/models.py:848
 msgid "Period origins"
 msgstr ""
 
-#: hours/models.py:875
+#: hours/models.py:903
 msgid ""
 "\n"
 "\n"
@@ -536,195 +536,195 @@ msgstr ""
 "\n"
 "Giltig när alla följanär gäller:\n"
 
-#: hours/models.py:891
+#: hours/models.py:919
 msgid "Start time"
 msgstr ""
 
-#: hours/models.py:894
+#: hours/models.py:922
 msgid "End time"
 msgstr ""
 
-#: hours/models.py:897
+#: hours/models.py:925
 msgid "Is end time on the next day"
 msgstr ""
 
-#: hours/models.py:899
+#: hours/models.py:927
 msgid "24 hours"
 msgstr "24 timmar"
 
-#: hours/models.py:903
+#: hours/models.py:931
 msgid "Weekday"
 msgstr "Veckodag"
 
-#: hours/models.py:917
+#: hours/models.py:945
 msgid "Time span"
 msgstr ""
 
-#: hours/models.py:918
+#: hours/models.py:946
 msgid "Time spans"
 msgstr ""
 
-#: hours/models.py:957
+#: hours/models.py:985
 msgctxt "timespan_as_text"
 msgid "Every day"
 msgstr "Varje dag"
 
-#: hours/models.py:984
+#: hours/models.py:1012
 msgctxt "timespan_as_text"
 msgid "The whole day"
 msgstr "Hela dagen"
 
-#: hours/models.py:986
+#: hours/models.py:1014
 #, python-brace-format
 msgctxt "timespan_as_text"
 msgid "{start_time}-{end_time}"
 msgstr ""
 
-#: hours/models.py:1003
+#: hours/models.py:1033
 #, python-brace-format
 msgctxt "timespan_as_text"
 msgid "{weekdays} {times} {state}{description}"
 msgstr ""
 
-#: hours/models.py:1022
+#: hours/models.py:1052
 msgid "Context"
 msgstr ""
 
-#: hours/models.py:1027
+#: hours/models.py:1057
 msgid "Subject"
 msgstr ""
 
-#: hours/models.py:1030
+#: hours/models.py:1060
 msgid "Start"
 msgstr "Början"
 
-#: hours/models.py:1032
+#: hours/models.py:1062
 msgid "Frequency (ordinal)"
 msgstr "Upprepning (sekvensnummer)"
 
-#: hours/models.py:1036
+#: hours/models.py:1066
 msgid "Frequency (modifier)"
 msgstr "Upprepning (kval)"
 
-#: hours/models.py:1043
+#: hours/models.py:1073
 msgid "Rule"
 msgstr "Reger"
 
-#: hours/models.py:1044
+#: hours/models.py:1074
 msgid "Rules"
 msgstr "Regler"
 
-#: hours/models.py:1074
+#: hours/models.py:1104
 msgctxt "rule_as_text_context"
 msgid "the period"
 msgstr "Av period"
 
-#: hours/models.py:1076
+#: hours/models.py:1106
 #, python-brace-format
 msgctxt "rule_as_text_context"
 msgid "every {context}"
 msgstr "Varje {context}"
 
-#: hours/models.py:1082
+#: hours/models.py:1112
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "{nth} {subject} in {context}"
 msgstr "{context} {nth} {subject}"
 
-#: hours/models.py:1091
+#: hours/models.py:1121
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "starting from the {nth} {last} {subject}"
 msgstr "från {nth} {last} {subject}"
 
-#: hours/models.py:1094
+#: hours/models.py:1124
 msgctxt "starting_from_the_last"
 msgid "last"
 msgstr "från den sista"
 
-#: hours/models.py:1104
+#: hours/models.py:1134
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "Every {nth} {subject} in {context} {starting_from_text}"
 msgstr "{context} varje {nth} {subject} {starting_from_text}"
 
-#: hours/models.py:1115
+#: hours/models.py:1145
 #, python-brace-format
 msgctxt "rule_as_text"
 msgid "On {modifier} {subject}s in {context}"
 msgstr "{context} varje {modifier} {subject}"
 
-#: hours/models.py:1136
+#: hours/models.py:1166
 msgid ""
 "We cannot start counting from period start in an infinite period. Please "
 "select shorter context for your rule."
 msgstr ""
 
-#: hours/models.py:1141
+#: hours/models.py:1171
 msgid "Subject must be a shorter timespan than context."
 msgstr ""
 
-#: hours/models.py:1145
+#: hours/models.py:1175
 msgid ""
 "You cannot add a rule with both even/odd and another frequency at the same "
 "time."
 msgstr ""
 
-#: hours/models.py:1154
+#: hours/models.py:1184
 msgid ""
 "Rule can only start from zero if starting from zeroth ISO week of the year. "
 "All other rules start counting from 1. Use negative numbers to count from "
 "the end of the context."
 msgstr ""
 
-#: hours/models.py:1162
+#: hours/models.py:1192
 msgid ""
 "Even/odd subjects are not counted starting from a specific time. If you wish "
 "to have an alternating rule starting from a specific time, please use "
 "frequency_ordinal=2 with start=1 or start=2."
 msgstr ""
 
-#: hours/models.py:1429
+#: hours/models.py:1459
 msgid "Signature"
 msgstr ""
 
-#: hours/models.py:1430
+#: hours/models.py:1460
 msgid "Signature created at"
 msgstr ""
 
-#: hours/models.py:1431
+#: hours/models.py:1461
 msgid "Signature valid until"
 msgstr ""
 
-#: hours/models.py:1433
+#: hours/models.py:1463
 msgid "Invalidated time"
 msgstr ""
 
-#: hours/models.py:1437
+#: hours/models.py:1467
 msgid "Signed auth entry"
 msgstr ""
 
-#: hours/models.py:1438
+#: hours/models.py:1468
 msgid "Signed auth entries"
 msgstr ""
 
-#: hours/models.py:1443
+#: hours/models.py:1473
 msgid "Signing key"
 msgstr ""
 
-#: hours/models.py:1444
+#: hours/models.py:1474
 msgid "Key valid after"
 msgstr ""
 
-#: hours/models.py:1446
+#: hours/models.py:1476
 msgid "Key valid until"
 msgstr ""
 
-#: hours/models.py:1450
+#: hours/models.py:1480
 msgid "Signed auth key"
 msgstr ""
 
-#: hours/models.py:1451
+#: hours/models.py:1481
 msgid "Signed auth keys"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "All data from data source {self.instance.id} is read-only."
 msgstr ""
 
-#: hours/serializers.py:352 hours/serializers.py:363
+#: hours/serializers.py:351 hours/serializers.py:362
 msgid ""
 "Cannot create or edit sub resources of a resource in an organisation the "
 "user is not part of "
@@ -771,33 +771,37 @@ msgstr ""
 msgid "start_date must be before end_date"
 msgstr ""
 
-#: hours/viewsets.py:555
+#: hours/viewsets.py:563
 msgid "target_resources parameter is required"
 msgstr ""
 
-#: hours/viewsets.py:579
+#: hours/viewsets.py:587
 msgid "Resource with the id \"{}\" not found."
 msgstr ""
 
-#: hours/viewsets.py:585
+#: hours/viewsets.py:593
 msgid "Can't copy date periods to self"
 msgstr ""
 
-#: hours/viewsets.py:597
+#: hours/viewsets.py:605
 msgid "No permission to modify resource(s): {}"
 msgstr ""
 
-#: hours/viewsets.py:707
+#: hours/viewsets.py:628
+msgid "Date periods not found: {}"
+msgstr ""
+
+#: hours/viewsets.py:747
 msgid ""
 "resource, start_date or end_date GET parameter is required to list date "
 "periods"
 msgstr ""
 
-#: hours/viewsets.py:757
+#: hours/viewsets.py:797
 msgid "resource GET parameter is required to list rules of resources"
 msgstr ""
 
-#: hours/viewsets.py:799
+#: hours/viewsets.py:839
 msgid "resource GET parameter is required to list time spans of resources"
 msgstr ""
 


### PR DESCRIPTION
The typo was supposed to be fixed in an earlier commit (44059c2), but wasn't.

EDIT: Also removed init_application.sh as it was causing problems (trying to compile messages in an environment where it has no write permissions)