### PR TITLE
fix: sort imported time spans before comparing to DB values

### DIFF
--- a/hours/enums.py
+++ b/hours/enums.py
@@ -1,5 +1,5 @@
 from django.utils.translation import pgettext_lazy
-from enumfields import Enum
+from enumfields import Enum, IntEnum
 
 
 class State(Enum):
@@ -83,7 +83,7 @@ class ResourceType(Enum):
         ENTRANCE = pgettext_lazy("ResourceType", "Entrance or exit")
 
 
-class Weekday(Enum):
+class Weekday(IntEnum):
     MONDAY = 1
     TUESDAY = 2
     WEDNESDAY = 3

--- a/hours/importer/base.py
+++ b/hours/importer/base.py
@@ -356,9 +356,21 @@ class Importer(object):
                 existing_time_spans = existing_group.time_spans.all()
                 existing_rules = existing_group.rules.all()
 
+            def default_getter(o):
+                return (
+                    o.get("weekdays"),
+                    o.get("start_time"),
+                    o.get("end_time_on_next_day"),
+                    o.get("end_time"),
+                    o.get("resource_state"),
+                )
+
+            # Sort imported time spans so they match DB order
+            sorted_time_spans = sorted(datum["time_spans"], key=default_getter)
+
             # if data didn't change, the time spans will be in db order
             for time_span_datum, existing_time_span in zip_longest(
-                datum["time_spans"], existing_time_spans, fillvalue=None
+                sorted_time_spans, existing_time_spans, fillvalue=None
             ):
                 if not time_span_datum:
                     existing_time_span.delete()

--- a/hours/tests/test_kirjastot_importer.py
+++ b/hours/tests/test_kirjastot_importer.py
@@ -1,0 +1,64 @@
+from datetime import time
+
+import pytest
+
+from hours.enums import State, Weekday
+from hours.importer.kirjastot import KirjastotImporter
+from hours.tests.conftest import ResourceFactory
+
+
+@pytest.mark.django_db
+def test_get_kirkanta_periods():
+    importer = KirjastotImporter({})
+    resource = ResourceFactory()
+
+    def get_data():
+        return {
+            "origins": [{"origin_id": 13, "data_source_id": importer.data_source.id}],
+            "resource": resource,
+            "time_span_groups": [
+                {
+                    "rules": [],
+                    "time_spans": [
+                        {
+                            "group": None,
+                            "start_time": time(hour=15, minute=0),
+                            "end_time": time(hour=20, minute=0),
+                            "weekdays": [Weekday.SATURDAY],
+                            "resource_state": State.OPEN,
+                            "full_day": False,
+                        },
+                        {
+                            "group": None,
+                            "start_time": time(hour=7, minute=0),
+                            "end_time": time(hour=15, minute=0),
+                            "weekdays": [Weekday.SATURDAY],
+                            "resource_state": State.SELF_SERVICE,
+                            "full_day": False,
+                        },
+                        {
+                            "group": None,
+                            "start_time": time(hour=20, minute=0),
+                            "end_time": time(hour=21, minute=0),
+                            "weekdays": [Weekday.SATURDAY],
+                            "resource_state": State.SELF_SERVICE,
+                            "full_day": False,
+                        },
+                    ],
+                }
+            ],
+        }
+
+    importer.save_dateperiod(get_data())
+    importer.save_dateperiod(get_data())
+    date_period = importer.save_dateperiod(get_data())
+
+    assert date_period.history.all().count() == 2
+    time_span_groups = date_period.time_span_groups.all()
+    assert len(time_span_groups) == 1
+    time_span_group = time_span_groups[0]
+    time_spans = time_span_group.time_spans.all()
+    assert len(time_spans) == 3
+    for time_span in time_spans:
+        # This would be 3 if history is incorrectly saved on every call
+        assert time_span.history.all().count() == 1

--- a/users/migrations/0004_userorigin_unique_user_per_data_source.py
+++ b/users/migrations/0004_userorigin_unique_user_per_data_source.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("users", "0003_userorigin"),
     ]


### PR DESCRIPTION
Imported time spans seem to be often in different order than our DB order which results in lots of extra writes and history entries.

refs: HAUKI-657