### PR TITLE
fix: speed up DatePeriodsAsTextForTprek

### DIFF
--- a/hours/tests/test_date_periods_as_text_for_tprek_api.py
+++ b/hours/tests/test_date_periods_as_text_for_tprek_api.py
@@ -59,6 +59,7 @@ def test_test_date_periods_as_text_for_tprek_api_with_past_date_periods(
     date_period_factory,
     time_span_group_factory,
     time_span_factory,
+    django_assert_num_queries,
 ):
     data_source = data_source_factory(id="tprek")
 
@@ -87,11 +88,12 @@ def test_test_date_periods_as_text_for_tprek_api_with_past_date_periods(
 
     url = reverse("date_periods_as_text_for_tprek-list")
 
-    with freeze_time("2020-10-17 12:00:00+02:00"):
-        response = admin_client.get(
-            url,
-            content_type="application/json",
-        )
+    with django_assert_num_queries(10):
+        with freeze_time("2020-10-17 12:00:00+02:00"):
+            response = admin_client.get(
+                url,
+                content_type="application/json",
+            )
 
     assert response.status_code == 200, "{} {}".format(
         response.status_code, response.data

--- a/hours/viewsets.py
+++ b/hours/viewsets.py
@@ -1100,7 +1100,6 @@ class DatePeriodsAsTextForTprek(viewsets.GenericViewSet):
                     ),
                 ),
             )
-            .distinct()
             .order_by("id")
         )
 

--- a/hours/viewsets.py
+++ b/hours/viewsets.py
@@ -6,7 +6,7 @@ import pytz
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Exists, OuterRef, Prefetch, Q
 from django.http import Http404
 from django.utils import timezone, translation
 from django.utils.translation import gettext_lazy as _
@@ -39,7 +39,7 @@ from rest_framework.response import Response
 from .authentication import HaukiSignedAuthData
 from .enums import State
 from .filters import DatePeriodFilter, TimeSpanFilter, parse_maybe_relative_date_string
-from .models import DatePeriod, Resource, Rule, TimeElement, TimeSpan
+from .models import DatePeriod, Resource, Rule, TimeElement, TimeSpan, TimeSpanGroup
 from .permissions import (
     IsMemberOrAdminOfOrganization,
     ReadOnlyPublic,
@@ -1066,19 +1066,39 @@ class DatePeriodsAsTextForTprek(viewsets.GenericViewSet):
     filter_backends = (DjangoFilterBackend, DatePeriodsAsTextForTprekBackend)
     pagination_class = PageSizePageNumberPagination
 
-    def get_queryset(self):
+    def get_queryset(self, time_now=None):
+        if not time_now:
+            time_now = timezone.now()
+        earliest_end_date = (time_now - datetime.timedelta(hours=26)).date()
         queryset = (
             Resource.objects.filter(
                 # Query only resources that have date periods
                 Exists(DatePeriod.objects.filter(resource=OuterRef("pk"))),
             )
+            .only("id", "name", "timezone")
             .prefetch_related(
                 "origins",
                 "origins__data_source",
-                "date_periods",
-                "date_periods__time_span_groups",
-                "date_periods__time_span_groups__time_spans",
-                "date_periods__time_span_groups__rules",
+                Prefetch(
+                    "date_periods",
+                    DatePeriod.objects.filter(
+                        Q(end_date__gte=earliest_end_date) | Q(end_date__isnull=True)
+                    ).prefetch_related(
+                        Prefetch(
+                            "time_span_groups",
+                            TimeSpanGroup.objects.all().prefetch_related(
+                                Prefetch(
+                                    "time_spans",
+                                    TimeSpan.objects.all().defer("name"),
+                                ),
+                                Prefetch(
+                                    "rules",
+                                    Rule.objects.all().defer("name", "description"),
+                                ),
+                            ),
+                        )
+                    ),
+                ),
             )
             .distinct()
             .order_by("id")
@@ -1092,9 +1112,10 @@ class DatePeriodsAsTextForTprek(viewsets.GenericViewSet):
         return queryset
 
     def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-        page = self.paginate_queryset(queryset)
         time_now = timezone.now()
+        queryset = self.filter_queryset(self.get_queryset(time_now))
+        page = self.paginate_queryset(queryset)
+
         results = []
 
         for resource in page:


### PR DESCRIPTION
fix: speed up DatePeriodsAsTextForTprek

Filtering DatePeriods that would be filtered in code anyway grants
a significant speed boost for kirkanta resources that have a lot of
historical DatePeriods. Additionally, a small boost is gained by
dropping fields that are not used in rendering the output.

In local tests with data dump from dev:

http://localhost:8000//v1/date_periods_as_text_for_tprek/
?data_source=kirkanta&page=1

count: 149
before: 3000-3900 ms, 9 queries @ 81 ms
after: 380-400 ms, 9 queries @ 37 ms

NOTE: test does 10 queries because it's done with authenticated user
which adds one extra query for the user.

refs: HAUKI-648