### PR TITLE
Speed up OpeningHours endpoint

### DIFF
--- a/hours/tests/test_opening_hours_api.py
+++ b/hours/tests/test_opening_hours_api.py
@@ -104,6 +104,7 @@ def test_opening_hours_date_period_with_hours_and_rule(
     time_span_group_factory,
     time_span_factory,
     rule_factory,
+    django_assert_num_queries,
 ):
     period = date_period_factory(
         resource=resource,
@@ -127,12 +128,12 @@ def test_opening_hours_date_period_with_hours_and_rule(
         "start_date": "2020-11-01",
         "end_date": "2020-11-30",
     }
-
-    response = admin_client.get(
-        url,
-        data=data,
-        content_type="application/json",
-    )
+    with django_assert_num_queries(9):
+        response = admin_client.get(
+            url,
+            data=data,
+            content_type="application/json",
+        )
 
     assert response.status_code == 200, "{} {}".format(
         response.status_code, response.data

--- a/hours/viewsets.py
+++ b/hours/viewsets.py
@@ -989,7 +989,6 @@ class OpeningHoursViewSet(viewsets.GenericViewSet):
                     ),
                 ),
             )
-            .distinct()
             .order_by("id")
         )
 


### PR DESCRIPTION
Limit the excessive number of rows that are being prefetched for speedier
processing of data.

http://localhost:8000/v1/opening_hours/?data_source=tprek&start_date=0w&end_date=4w&page=3&format=json

before: 1200-1300 ms, 9 queries @ 30-40 ms
after: 280-380 ms,  9 queries @ 30-40 ms

----

When filtering using Exists() there is no risk of introducing duplicate
rows.

http://localhost:8000/v1/opening_hours/?data_source=tprek&start_date=0w&end_date=4w&page=3&page_size=10

Query time goes from 30-40 ms to <20 ms