### PR TITLE
fix(importer): remove re.U as count argument

### DIFF
--- a/hours/importer/base.py
+++ b/hours/importer/base.py
@@ -108,9 +108,11 @@ class Importer(object):
         text = text.replace("\u0000", " ")
         if strip_newlines:
             text = text.replace("\r", "").replace("\n", " ")
-        # TODO check this, re.U seems to be erroneously used as count
         # remove consecutive whitespaces
-        return re.sub(r"\s\s+", " ", text, re.U).strip()  # noqa: B034
+        # NOTE: re.U is most likely redundant, but the redundancy is mentioned
+        # only from 3.11 onwards. Keeping it for now.
+        # See: https://docs.python.org/3.11/library/re.html#re.U
+        return re.sub(r"\s\s+", " ", text, flags=re.U).strip()
 
     def _set_field(self, obj: object, field_name: str, val: object):
         """


### PR DESCRIPTION
Most likely meant to be used as a flag, not as a count argument.

The flag itself seems to be redundant, but it's mentioned only from 3.11 onwards in the documentation. Keeping it for now.
See: https://docs.python.org/3.11/library/re.html#re.U

Refs: HAUKI-668