### PR TITLE
fix: handle errors while parsing dates in filters

### DIFF
--- a/hours/tests/test_dateperiod_api.py
+++ b/hours/tests/test_dateperiod_api.py
@@ -11,6 +11,18 @@ from hours.tests.utils import assert_response_status_code
 
 
 @pytest.mark.django_db
+def test_invalid_format_returns_400(admin_client):
+    url = reverse("date_period-list")
+
+    response = admin_client.get(url, data={"start_date_lte": "2030-101-01"})
+
+    assert response.status_code == 400, "{} {}".format(
+        response.status_code, response.data
+    )
+    assert response.data["start_date_lte"][0] == "Invalid date format"
+
+
+@pytest.mark.django_db
 def test_list_date_periods_empty(admin_client):
     url = reverse("date_period-list")
 

--- a/hours/tests/test_opening_hours_api.py
+++ b/hours/tests/test_opening_hours_api.py
@@ -2,6 +2,28 @@ import datetime
 
 import pytest
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+
+@pytest.mark.django_db
+def test_opening_hours_invalid_date(admin_client):
+    url = reverse("opening_hours-list")
+
+    data = {
+        "start_date": "2020-101-01",
+        "end_date": "2020-11-30",
+    }
+
+    response = admin_client.get(
+        url,
+        data=data,
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400, "{} {}".format(
+        response.status_code, response.data
+    )
+    assert response.data[0] == _("Invalid start_date")
 
 
 @pytest.mark.django_db

--- a/hours/tests/test_parse_filter_date.py
+++ b/hours/tests/test_parse_filter_date.py
@@ -85,3 +85,8 @@ from hours.filters import parse_maybe_relative_date_string
 def test_parse_filter_date(input_string, end_date, frozen_date, expected_date):
     with freeze_time(frozen_date):
         assert parse_maybe_relative_date_string(input_string, end_date) == expected_date
+
+
+def test_parse_errors():
+    with pytest.raises(ValueError):
+        parse_maybe_relative_date_string("2020-101-3")


### PR DESCRIPTION
There were error, handling returned value of the date string parser. Problem was that the parser could return None value which was compared against other None or date which obviously does not compute.

Solution to this is to fail early on the parser function and handle the error correctly where the parser function is used. This lead to writing error handling to the MaybeRelativeDateField since the viewset using the function was correctly handling errors (just not the None values).

Before this, when giving badly formatted date parameter in the dateperiod end would have been okay and all the periods would be returned - not anymore, now it returns a validation error.

Refs HAUKI-564