### PR TITLE
Fix deprecations

### DIFF
--- a/hours/models.py
+++ b/hours/models.py
@@ -22,6 +22,7 @@ from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext
 from django_orghierarchy.models import Organization
+from model_utils.managers import SoftDeletableManager
 from model_utils.models import SoftDeletableModel, TimeStampedModel
 from timezone_field import TimeZoneField
 
@@ -309,6 +310,8 @@ class DataSource(SoftDeletableModel, TimeStampedModel):
         verbose_name = _("Data source")
         verbose_name_plural = _("Data sources")
 
+    objects = SoftDeletableManager()
+
     def __str__(self):
         return self.id
 
@@ -380,6 +383,8 @@ class Resource(SoftDeletableModel, TimeStampedModel):
         verbose_name = _("Resource")
         verbose_name_plural = _("Resources")
         indexes = (models.Index(fields=["created"]), models.Index(fields=["modified"]))
+
+    objects = SoftDeletableManager()
 
     def __str__(self):
         return str(self.name)
@@ -664,6 +669,8 @@ class DatePeriod(SoftDeletableModel, TimeStampedModel):
         ordering = ["start_date"]
         indexes = (models.Index(fields=["created"]), models.Index(fields=["modified"]))
 
+    objects = SoftDeletableManager()
+
     def __str__(self):
         return (
             f"{self.name}({self.start_date} - {self.end_date} "
@@ -868,6 +875,8 @@ class TimeSpanGroup(SoftDeletableModel, models.Model):
     def __str__(self):
         return f"{self.period} time spans {self.time_spans.all()}"
 
+    objects = SoftDeletableManager()
+
     def as_hash_input(self) -> str:
         time_span_strings = []
         for time_span in self.time_spans.all():
@@ -954,6 +963,8 @@ class TimeSpan(SoftDeletableModel, TimeStampedModel):
             "end_time",
             "resource_state",
         ]
+
+    objects = SoftDeletableManager()
 
     def __str__(self):
         if self.weekdays:
@@ -1082,6 +1093,8 @@ class Rule(SoftDeletableModel, TimeStampedModel):
     class Meta:
         verbose_name = _("Rule")
         verbose_name_plural = _("Rules")
+
+    objects = SoftDeletableManager()
 
     def __str__(self):
         if self.frequency_modifier:

--- a/hours/tests/conftest.py
+++ b/hours/tests/conftest.py
@@ -77,27 +77,30 @@ class ResourceOriginFactory(factory.django.DjangoModelFactory):
 class DatePeriodFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = DatePeriod
+        skip_postgeneration_save = True
 
     name = factory.LazyAttribute(lambda x: "DP-" + faker.pystr())
     start_date = factory.LazyAttribute(lambda x: faker.date())
 
     @factory.post_generation
-    def origins(self, create, extracted, **__):
+    def origins(obj, create, extracted, **__):  # noqa: N805
         if not create or not extracted:
             return
 
         for origin in extracted:
-            self.origins.add(origin)
+            obj.origins.add(origin)
+        obj.save()
 
     @factory.post_generation
-    def data_sources(self, create, extracted, **__):
+    def data_sources(obj, create, extracted, **__):  # noqa: N805
         if not create or not extracted:
             return
 
         for data_source in extracted:
             # Create a new origin for each data source, since data sources
             # are accessed through origins.
-            self.origins.add(PeriodOriginFactory(data_source=data_source, period=self))
+            obj.origins.add(PeriodOriginFactory(data_source=data_source, period=obj))
+        obj.save()
 
 
 @register

--- a/hours/tests/conftest.py
+++ b/hours/tests/conftest.py
@@ -182,13 +182,13 @@ def hsa_params_factory():
         if not signed_auth_key:
             signed_auth_key = SignedAuthKeyFactory(data_source=data_source)
 
-        now = datetime.datetime.utcnow()
+        now = timezone.now()
 
         data = {
             "hsa_source": data_source.id,
             "hsa_username": user.username if user else username,
-            "hsa_created_at": now.isoformat() + "Z",
-            "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+            "hsa_created_at": now.isoformat(),
+            "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
             "hsa_has_organization_rights": str(has_organization_rights),
         }
 

--- a/hours/tests/test_hauki_signed_auth.py
+++ b/hours/tests/test_hauki_signed_auth.py
@@ -125,14 +125,16 @@ def test_get_auth_required_header_timezone_missing_created_at(
 
     url = reverse("auth_required_test-list")
 
-    now = datetime.datetime.utcnow()
+    naive_now = datetime.datetime.now(tz=None)
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat(),
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat()
-        + "-04:00",
+        "hsa_created_at": naive_now.isoformat(),
+        "hsa_valid_until": (
+            naive_now.astimezone(tz=datetime.timezone(-datetime.timedelta(hours=4)))
+            + datetime.timedelta(minutes=10)
+        ).isoformat(),
     }
 
     source_string = join_params(data)
@@ -184,13 +186,13 @@ def test_get_auth_required_header_timezone_missing_valid_until(
 
     url = reverse("auth_required_test-list")
 
-    now = datetime.datetime.utcnow()
+    naive_now = datetime.datetime.now(tz=None)
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
+        "hsa_created_at": naive_now.astimezone(datetime.timezone.utc).isoformat(),
+        "hsa_valid_until": (naive_now + datetime.timedelta(minutes=10)).isoformat(),
     }
 
     source_string = join_params(data)
@@ -214,13 +216,13 @@ def test_get_auth_required_header_timezone_missing_created_at_and_valid_until(
 
     url = reverse("auth_required_test-list")
 
-    now = datetime.datetime.utcnow()
+    naive_now = datetime.datetime.now(tz=None)
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat(),
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
+        "hsa_created_at": naive_now.isoformat(),
+        "hsa_valid_until": (naive_now + datetime.timedelta(minutes=10)).isoformat(),
     }
 
     source_string = join_params(data)
@@ -244,13 +246,13 @@ def test_get_auth_required_header_authenticated(
 
     url = reverse("auth_required_test-list")
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
     }
 
     source_string = join_params(data)
@@ -276,13 +278,13 @@ def test_join_user_to_organization(
 
     url = reverse("auth_required_test-list")
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
         "hsa_organization": org.id,
     }
 
@@ -320,13 +322,13 @@ def test_join_user_to_organization_existing_user(
 
     url = reverse("auth_required_test-list")
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": user.username,
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
         "hsa_organization": org.id,
     }
 
@@ -366,13 +368,13 @@ def test_join_user_to_organization_existing_user_and_organisation(
 
     url = reverse("auth_required_test-list")
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": user.username,
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
         "hsa_organization": org.id,
     }
 
@@ -400,13 +402,13 @@ def test_join_user_to_organization_invalid_org(
 
     url = reverse("auth_required_test-list")
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
         "hsa_organization": "test:2345",
     }
 
@@ -434,14 +436,14 @@ def test_signed_auth_entry_not_invalidated(
 
     url = reverse("auth_required_test-list")
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
     valid_until = now + datetime.timedelta(minutes=10)
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": valid_until.isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": valid_until.isoformat(),
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
@@ -478,15 +480,15 @@ def test_invalidate_signature_success_header_params(
 
     signed_auth_key = signed_auth_key_factory(data_source=data_source)
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     valid_until = now + datetime.timedelta(minutes=10)
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": valid_until.isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": valid_until.isoformat(),
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
@@ -527,13 +529,13 @@ def test_invalidate_signature_success_query_params(
 
     url = reverse("auth_required_test-list")
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
@@ -574,13 +576,13 @@ def test_invalidate_signature_invalid_params(
 ):
     signed_auth_key = signed_auth_key_factory(data_source=data_source)
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source.id,
         # hsa_username missing
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
@@ -602,13 +604,13 @@ def test_invalidate_signature_missing_timezone(
 ):
     signed_auth_key = signed_auth_key_factory(data_source=data_source)
 
-    now = datetime.datetime.utcnow()
+    naive_now = datetime.datetime.now(tz=None)
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat(),
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
+        "hsa_created_at": naive_now.isoformat(),
+        "hsa_valid_until": (naive_now + datetime.timedelta(minutes=10)).isoformat(),
     }
 
     signature = calculate_signature(signed_auth_key.signing_key, join_params(data))
@@ -629,13 +631,13 @@ def test_invalidate_signature_missing_timezone(
 def test_authenticate_new_user(api_client, data_source, signed_auth_key_factory):
     signed_auth_key = signed_auth_key_factory(data_source=data_source)
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": "test_user",
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
     }
 
     source_string = join_params(data)
@@ -663,13 +665,13 @@ def test_authenticate_existing_user_no_existing_data_source(
 
     user = user_factory()
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": user.username,
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
     }
 
     source_string = join_params(data)
@@ -698,13 +700,13 @@ def test_authenticate_existing_user_existing_same_data_source(
     user = user_factory()
     user_origin_factory(user=user, data_source=data_source)
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source.id,
         "hsa_username": user.username,
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
     }
 
     source_string = join_params(data)
@@ -740,13 +742,13 @@ def test_authenticate_existing_user_existing_different_data_source(
     user = user_factory()
     user_origin_factory(user=user, data_source=data_source2)
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     data = {
         "hsa_source": data_source1.id,
         "hsa_username": user.username,
-        "hsa_created_at": now.isoformat() + "Z",
-        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat() + "Z",
+        "hsa_created_at": now.isoformat(),
+        "hsa_valid_until": (now + datetime.timedelta(minutes=10)).isoformat(),
     }
 
     source_string = join_params(data)

--- a/hours/tests/test_import.py
+++ b/hours/tests/test_import.py
@@ -95,7 +95,6 @@ def mock_tprek_data(requests_mock, request):
     }
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def mock_library_data(requests_mock, request):
     # We should have the same hours whether base period is endless or ends next year


### PR DESCRIPTION
Address the following deprecation warnings:
- [utcnow is deprecated][utcnow-deprecation]
- [factory_boy's post generation hooks stop calling save automatically][factoryboy-deprecation]
- [SoftDeletableModel.objects returns all objects][django-model-utils-deprecation]
  - Note that this wasn't fixed as suggested (replacing objects manager references with available_objects manager) since third-party dependencies also use the objects manager
  - This could cause unexpected behaviour, so instead, we replace objects with SoftDeletableManager to ensure it functions as before
- [pytest fixtures should not have marks][pytest-deprecation]

Refs: HAUKI-721, HAUKI-727

[pytest-deprecation]: https://docs.pytest.org/en/8.2.x/deprecations.html#applying-a-mark-to-a-fixture-function
[factoryboy-deprecation]: https://factoryboy.readthedocs.io/en/3.3.0/changelog.html#id1
[django-model-utils-deprecation]: https://django-model-utils.readthedocs.io/en/4.5.1/changelog.html#id8
[utcnow-deprecation]: https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow