### PR TITLE
fix: filter override flag consistently in combine_element_time_spans

### DIFF
--- a/hours/models.py
+++ b/hours/models.py
@@ -139,7 +139,11 @@ def combine_element_time_spans(elements, override=False):
     states = {el.resource_state for el in elements if el.override == override}
 
     for state in states:
-        state_elements = [el for el in elements if el.resource_state == state]
+        state_elements = [
+            el
+            for el in elements
+            if el.resource_state == state and el.override == override
+        ]
 
         # This will return those with start_time None first.
         # Other fields being equal, this will return those with end_time None last.

--- a/hours/tests/test_time_element.py
+++ b/hours/tests/test_time_element.py
@@ -1,7 +1,11 @@
 import datetime
 
 from hours.enums import State
-from hours.models import TimeElement, combine_and_apply_override
+from hours.models import (
+    TimeElement,
+    combine_and_apply_override,
+    combine_element_time_spans,
+)
 
 
 def test_combine_and_apply_override_full_day_override():
@@ -409,3 +413,150 @@ def test_combine_and_apply_override_two_next_day_ends():
     )
 
     assert combine_and_apply_override([te1, te2]) == [expected]
+
+
+# ---------------------------------------------------------------------------
+# Tests for combine_element_time_spans – override flag validity
+# ---------------------------------------------------------------------------
+def _te(
+    start, end, state=State.OPEN, override=False, end_next_day=False, full_day=False
+):
+    return TimeElement(
+        start_time=start,
+        end_time=end,
+        end_time_on_next_day=end_next_day,
+        resource_state=state,
+        override=override,
+        full_day=full_day,
+    )
+
+
+class TestCombineElementTimeSpansOverrideFlag:
+    def test_default_returns_only_non_override_elements(self):
+        non_override = _te(
+            datetime.time(8), datetime.time(16), state=State.OPEN, override=False
+        )
+        overriding = _te(
+            datetime.time(10), datetime.time(14), state=State.OPEN, override=True
+        )
+
+        result = combine_element_time_spans([non_override, overriding])
+
+        assert all(not el.override for el in result)
+        assert result == [non_override]
+
+    def test_override_true_returns_only_overriding_elements(self):
+        non_override = _te(
+            datetime.time(8), datetime.time(16), state=State.OPEN, override=False
+        )
+        overriding = _te(
+            datetime.time(10), datetime.time(14), state=State.CLOSED, override=True
+        )
+
+        result = combine_element_time_spans([non_override, overriding], override=True)
+
+        assert all(el.override for el in result)
+        assert result == [overriding]
+
+    def test_mixed_override_same_state_not_combined(self):
+        non_override = _te(
+            datetime.time(8), datetime.time(12), state=State.OPEN, override=False
+        )
+        overriding = _te(
+            datetime.time(10), datetime.time(16), state=State.OPEN, override=True
+        )
+
+        # Ask for override=False → should only combine the non-overriding element
+        result_false = combine_element_time_spans(
+            [non_override, overriding], override=False
+        )
+        assert result_false == [non_override]
+
+        result_true = combine_element_time_spans(
+            [non_override, overriding], override=True
+        )
+        assert result_true == [overriding]
+
+    def test_two_overlapping_non_override_combined(self):
+        te1 = _te(datetime.time(8), datetime.time(12), state=State.OPEN, override=False)
+        te2 = _te(
+            datetime.time(10), datetime.time(16), state=State.OPEN, override=False
+        )
+
+        result = combine_element_time_spans([te1, te2])
+
+        assert result == [
+            TimeElement(
+                start_time=datetime.time(8),
+                end_time=datetime.time(16),
+                end_time_on_next_day=False,
+                resource_state=State.OPEN,
+                override=False,
+                full_day=False,
+            )
+        ]
+
+    def test_two_overlapping_overriding_combined(self):
+        te1 = _te(
+            datetime.time(12), datetime.time(14), state=State.CLOSED, override=True
+        )
+        te2 = _te(
+            datetime.time(13), datetime.time(15), state=State.CLOSED, override=True
+        )
+
+        result = combine_element_time_spans([te1, te2], override=True)
+
+        assert result == [
+            TimeElement(
+                start_time=datetime.time(12),
+                end_time=datetime.time(15),
+                end_time_on_next_day=False,
+                resource_state=State.CLOSED,
+                override=True,
+                full_day=False,
+            )
+        ]
+
+    def test_different_states_different_override_all_separated(self):
+        open_normal = _te(
+            datetime.time(8), datetime.time(12), state=State.OPEN, override=False
+        )
+        closed_normal = _te(
+            datetime.time(13), datetime.time(17), state=State.CLOSED, override=False
+        )
+        open_override = _te(
+            datetime.time(9), datetime.time(11), state=State.OPEN, override=True
+        )
+
+        result_false = combine_element_time_spans(
+            [open_normal, closed_normal, open_override], override=False
+        )
+        assert all(not el.override for el in result_false)
+        states_false = {el.resource_state for el in result_false}
+        assert State.OPEN in states_false
+        assert State.CLOSED in states_false
+
+        result_true = combine_element_time_spans(
+            [open_normal, closed_normal, open_override], override=True
+        )
+        assert result_true == [open_override]
+
+    def test_empty_elements_returns_empty(self):
+        assert combine_element_time_spans([]) == []
+
+    def test_no_matching_override_returns_empty(self):
+        non_override = _te(
+            datetime.time(8), datetime.time(16), state=State.OPEN, override=False
+        )
+        assert combine_element_time_spans([non_override], override=True) == []
+
+    def test_result_override_flag_matches_parameter(self):
+
+        for flag in (False, True):
+            elements = [
+                _te(
+                    datetime.time(8), datetime.time(16), state=State.OPEN, override=flag
+                )
+            ]
+            result = combine_element_time_spans(elements, override=flag)
+            assert all(el.override == flag for el in result)


### PR DESCRIPTION
Previously, state_elements was built without filtering by the override parameter, causing elements with the same resource_state but different override values to be mixed together during combining.

Add override filter to state_elements list comprehension and add tests covering the corrected behaviour.

Refs: [HAUKI-804](https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-804)

[HAUKI-804]: https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ