### PR TITLE
fix(release-please): update uv.lock TOML JSONPath

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,14 +5,6 @@
     ".": {
       "release-type": "python",
       "package-name": "hauki",
-        "extra-files": [
-          {"path": "pyproject.toml", "type": "toml"},
-          {
-            "path": "uv.lock",
-            "type": "toml",
-            "jsonpath": "$.package[?(@.name=='hauki')].version"
-          }
-        ],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},
@@ -26,6 +18,13 @@
         {"type": "test", "section": "Tests", "hidden": true},
         {"type": "build", "section": "Build System", "hidden": true},
         {"type": "ci", "section": "Continuous Integration", "hidden": true}
+      ],
+      "extra-files": [
+        {
+          "path": "uv.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='hauki')].version"
+        }
       ]
     }
   },


### PR DESCRIPTION
Updates:
- Fix the uv.lock TOML JSONPath from @.name to @.name.value, which matches release-please’s tagged TOML parser.
- Remove the redundant pyproject.toml extra-files entry. The python release type already updates pyproject.toml.

Refs: [HAUKI-808](https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-808)

[HAUKI-808]: https://helsinkisolutionoffice.atlassian.net/browse/HAUKI-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ