### PR TITLE
test: fix flaky test

### DIFF
--- a/hours/tests/test_dateperiod_api.py
+++ b/hours/tests/test_dateperiod_api.py
@@ -183,6 +183,7 @@ def test_list_date_periods_filter_by_resource_direct_data_source(
     resource.data_sources.add(expected_data_source)
     expected_date_period = date_period_factory(
         resource=resource,
+        start_date=datetime.date(year=2024, month=1, day=1),
     )
     date_period_factory(
         resource=resource_factory(),


### PR DESCRIPTION
test_list_date_periods_filter_by_resource_direct_data_source was flaky because DatePeriodFactory assigns a random start_date via faker.date(). If it fell after 2024-01-05, the expected period was filtered out. On 2026-07-24, that occurred approximately 4.51% of runs.

Refs: HAUKI-812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated date-period test expectations to include an explicit start date of January 1, 2024.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->